### PR TITLE
added a note regarding out of virtual memory issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ There's quite a difference in speed.
 Basically, everywhere you see `make` you can type `ninja` instead. Again, see
 [build.sh][27] for an example.
 
+Possible build troubles:
+-----------------------
+* While running ```build.sh``` under linux with ```gcc``` you may encounter ```virtual memory exhausted: Cannot allocate memory```, common solution for which is to [allocate swap space](http://www.cyberciti.biz/faq/linux-add-a-swap-file-howto/).
+
 Usage:
 ------
 CDT-plusplus uses [docopt][19] to parse options from the help message, and so


### PR DESCRIPTION
Hi,
I faced this problem while compiling CDT++ on ubuntu 14.04, so I thought of adding it as a note in README. 

