### PR TITLE
Include osx/gcc in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ matrix:
   exclude:
     - os: linux
       compiler: clang
-    - os: osx
-      compiler: gcc
+    # - os: osx
+    #   compiler: gcc
   allow_failures:
     - os: osx
 

--- a/install-osx.sh
+++ b/install-osx.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Install gcc 5.3
+if [[ "$CXX" = "g++" ]]; then brew install gcc; fi
+if [[ "$CXX" = "g++" ]]; then export CXX="g++-5" CC="gcc-5"; fi
+
 brew install cmake
 brew install ninja
 brew install eigen


### PR DESCRIPTION
It's straightforward to add osx/gcc.

I should've used branching earlier to avoid cluttering the master branch.