### PR TITLE
Comprehensive move tests

### DIFF
--- a/src/Metropolis.h
+++ b/src/Metropolis.h
@@ -630,9 +630,9 @@ class Metropolis {
   ///< Number of passes of ergodic moves on triangulation.
   std::uintmax_t checkpoint_ {10};
   ///< How often to print/write output.
-  move_tuple attempted_moves_ {0, 0, 0, 0, 0};
+  Move_tuple attempted_moves_ {0, 0, 0, 0, 0};
   ///< Attempted (2,3), (3,2), (2,6), (6,2), and (4,4) moves.
-  move_tuple successful_moves_ {0, 0, 0, 0, 0};
+  Move_tuple successful_moves_ {0, 0, 0, 0, 0};
   ///< Successful (2,3), (3,2), (2,6), (6,2), and (4,4) moves.
   std::tuple<std::vector<Cell_handle>,
              std::vector<Cell_handle>,

--- a/src/MoveManager.h
+++ b/src/MoveManager.h
@@ -64,7 +64,7 @@ class PachnerMove {
   template <typename T>
   void make_move(T&&, move_type);
 
-  move_tuple attempted_moves_;
+  Move_tuple attempted_moves_;
   std::tuple<std::vector<Cell_handle>,
              std::vector<Cell_handle>,
              std::vector<Cell_handle>> movable_simplex_types_;

--- a/src/MoveManager.h
+++ b/src/MoveManager.h
@@ -2,18 +2,18 @@
 ///
 /// Copyright (c) 2016 Adam Getchell
 ///
-/// RAII class for managing exception-safe ergodic (foliation-preserving
-/// Pachner) moves.
+/// Resource Aquisition Is Initialization class for managing exception-safe
+/// ergodic (foliation-preserving Pachner) moves.
 /// See http://www.stroustrup.com/except.pdf and
 /// http://exceptionsafecode.com for details.
 ///
-/// @file PachnerMove.h
-/// @brief Resource Aquisition Is Initialization class to manage
-/// exception-safe Pachner moves
+/// @file MoveManager.h
+/// @brief RAII class to manage exception-safe foliation-preserving
+/// Pachner moves
 /// @author Adam Getchell
 
-#ifndef SRC_PACHNERMOVE_H_
-#define SRC_PACHNERMOVE_H_
+#ifndef SRC_MOVEMANAGER_H_
+#define SRC_MOVEMANAGER_H_
 
 #include <tuple>
 #include <memory>
@@ -103,4 +103,4 @@ void PachnerMove::make_move(T&& universe, const move_type move) {
 }  // make_move()
 
 
-#endif  // SRC_PACHNERMOVE_H_
+#endif  // SRC_MOVEMANAGER_H_

--- a/src/S3ErgodicMoves.h
+++ b/src/S3ErgodicMoves.h
@@ -38,7 +38,7 @@
 #include <algorithm>
 #include <tuple>
 
-using move_tuple = std::tuple<std::uintmax_t,
+using Move_tuple = std::tuple<std::uintmax_t,
                               std::uintmax_t,
                               std::uintmax_t,
                               std::uintmax_t,

--- a/src/S3ErgodicMoves.h
+++ b/src/S3ErgodicMoves.h
@@ -410,6 +410,8 @@ auto make_26_move(T1&& universe_ptr,
     }
   // Increment the (2,6) move counter
   ++std::get<2>(attempted_moves);
+  // Erase the attempted (1,3) simplex from simplex_types
+  std::get<2>(simplex_types).erase(std::get<2>(simplex_types).begin() + choice);
   }
   return universe_ptr;
 }  // make_26_move()

--- a/src/S3Triangulation.h
+++ b/src/S3Triangulation.h
@@ -44,9 +44,8 @@
 #ifndef SRC_S3TRIANGULATION_H_
 #define SRC_S3TRIANGULATION_H_
 
-// CDT headers
-#include "utilities.h"
-
+// C headers
+// #include <math.h>
 
 // CGAL headers
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
@@ -54,9 +53,6 @@
 #include <CGAL/Triangulation_cell_base_with_info_3.h>
 #include <CGAL/Delaunay_triangulation_3.h>
 #include <CGAL/point_generators_3.h>
-
-// C headers
-// #include <math.h>
 
 // C++ headers
 #include <boost/iterator/zip_iterator.hpp>
@@ -66,6 +62,9 @@
 #include <tuple>
 #include <list>
 #include <set>
+
+// CDT headers
+#include "src/utilities.h"
 
 
 using K = CGAL::Exact_predicates_inexact_constructions_kernel;
@@ -107,7 +106,7 @@ static constexpr unsigned DIMENSION = 3;
 /// **spacelike_edges**, since we don't do much with them other than use them
 /// to check correctness.
 ///
-/// @param[in] universe_ptr A std::unique_ptr to the Delaunay triangulation
+/// @param[in] universe_ptr A std::unique_ptr<Delaunay> to the triangulation
 /// @returns A std::pair<std::vector<Edge_tuple>, unsigned> of timelike edges
 /// and spacelike edges
 template <typename T>
@@ -163,7 +162,7 @@ auto classify_edges(T&& universe_ptr) noexcept {
 /// Cell_handles to all the simplices in the triangulation of that corresponding
 /// type.
 ///
-/// @param[in] universe_ptr A std::unique_ptr to the Delaunay triangulation
+/// @param[in] universe_ptr A std::unique_ptr<Delaunay> to the triangulation
 /// @returns A std::tuple<std::vector, std::vector, std::vector> of
 /// **three_one**, **two_two**, and **one_three**
 template <typename T>
@@ -239,7 +238,7 @@ auto classify_simplices(T&& universe_ptr) {
 /// This function is repeatedly called by fix_triangulation() up to
 /// **MAX_FOLIATION_FIX_PASSES** times.
 ///
-/// @param[in] universe_ptr A std::unique_ptr to the Delaunay triangulation
+/// @param[in] universe_ptr A std::unique_ptr<Delaunay> to the triangulation
 /// @returns A boolean value if there are invalid simplices
 template <typename T>
 auto fix_timeslices(T&& universe_ptr) {  // NOLINT
@@ -325,7 +324,7 @@ auto fix_timeslices(T&& universe_ptr) {  // NOLINT
 /// Runs fix_timeslices() to fix foliation until there are no errors,
 /// or MAX_FOLIATION_FIX_PASSES whichever comes first.
 ///
-/// @param[in] universe_ptr A std::unique_ptr to the Delaunay triangulation
+/// @param[in] universe_ptr A std::unique_ptr<Delaunay> to the triangulation
 template <typename T>
 void fix_triangulation(T&& universe_ptr) {
   auto pass = 0;
@@ -340,9 +339,10 @@ void fix_triangulation(T&& universe_ptr) {
 
 /// @brief Inserts vertices with timeslices into Delaunay triangulation
 ///
-/// @param[in] universe_ptr A std::unique_ptr to the Delaunay triangulation
+/// @param[in] universe_ptr A std::unique_ptr<Delaunay> to the triangulation
 /// @param[in] causal_vertices A std::pair<std::vector, unsigned> containing
 /// the vertices to be inserted along with their timevalues
+/// @returns  A std::unique_ptr<Delaunay> to the triangulation
 template <typename T1, typename T2>
 void insert_into_triangulation(T1&& universe_ptr,
                                T2&& causal_vertices) noexcept {
@@ -350,6 +350,7 @@ void insert_into_triangulation(T1&& universe_ptr,
     (causal_vertices.first.begin(), causal_vertices.second.begin())),
      boost::make_zip_iterator(boost::make_tuple(causal_vertices.first.end(),
      causal_vertices.second.end())));
+  // return std::move(universe_ptr);
 }  // insert_into_triangulation()
 
 /// @brief Make foliated spheres
@@ -400,7 +401,7 @@ auto inline make_foliated_sphere(const unsigned simplices,
 ///
 /// @param[in] simplices  The number of desired simplices in the triangulation
 /// @param[in] timeslices The number of timeslices in the triangulation
-/// @returns A std::unique_ptr to the foliated Delaunay triangulation
+/// @returns A std::unique_ptr<Delaunay> to the foliated triangulation
 auto inline make_triangulation(const unsigned simplices,
                                const unsigned timeslices) {
   std::cout << "Generating universe ... " << std::endl;

--- a/src/S3Triangulation.h
+++ b/src/S3Triangulation.h
@@ -86,6 +86,7 @@ using Vertex_handle = Delaunay::Vertex_handle;
 using Locate_type = Delaunay::Locate_type;
 using Point = Delaunay::Point;
 using Edge_tuple = std::tuple<Cell_handle, unsigned, unsigned>;
+using Causal_vertices = std::pair<std::vector<Point>, std::vector<uintmax_t>>;
 
 static constexpr unsigned MAX_FOLIATION_FIX_PASSES = 200;
 ///< The maximum number of passes to fix invalidly foliated simplices
@@ -340,8 +341,9 @@ void fix_triangulation(T&& universe_ptr) {
 /// @brief Inserts vertices with timeslices into Delaunay triangulation
 ///
 /// @param[in] universe_ptr A std::unique_ptr<Delaunay> to the triangulation
-/// @param[in] causal_vertices A std::pair<std::vector, unsigned> containing
-/// the vertices to be inserted along with their timevalues
+/// @param[in] causal_vertices A std::pair<std::vector<Point>,
+/// std::vector<uintmax_t>> containing the vertices to be inserted along with
+/// their timevalues
 /// @returns  A std::unique_ptr<Delaunay> to the triangulation
 template <typename T1, typename T2>
 void insert_into_triangulation(T1&& universe_ptr,
@@ -370,7 +372,8 @@ auto inline make_foliated_sphere(const unsigned simplices,
   const auto points_per_timeslice = expected_points_per_simplex(DIMENSION,
                                     simplices, timeslices);
   CGAL_triangulation_precondition(points_per_timeslice >= 4);
-  std::pair<std::vector<Point>, std::vector<unsigned>> causal_vertices;
+  // std::pair<std::vector<Point>, std::vector<unsigned>> causal_vertices;
+  Causal_vertices causal_vertices;
 
   for (auto i = 0; i < timeslices; ++i) {
     radius = 1.0 + static_cast<double>(i);

--- a/unittests/MoveManagerTest.cpp
+++ b/unittests/MoveManagerTest.cpp
@@ -2,10 +2,10 @@
 ///
 /// Copyright (c) 2016 Adam Getchell
 ///
-/// Checks that the PachnerMove RAII class handles resources properly.
+/// Checks that the MoveManager RAII class handles resources properly.
 
-/// @file PachnerMoveTest.cpp
-/// @brief Tests for the PachnerMove RAII class
+/// @file MoveManagerTest.cpp
+/// @brief Tests for the MoveManager RAII class
 /// @author Adam Getchell
 
 #include <tuple>
@@ -14,14 +14,14 @@
 #include <algorithm>
 
 #include "gmock/gmock.h"
-#include "PachnerMove.h"
+#include "MoveManager.h"
 #include "S3ErgodicMoves.h"
 
 using namespace testing;  // NOLINT
 
-class PachnerMoveTest : public Test {
+class MoveManagerTest : public Test {
  public:
-  PachnerMoveTest() : universe_(std::move(make_triangulation(6400, 17))),
+  MoveManagerTest() : universe_(std::move(make_triangulation(6400, 17))),
                       movable_simplex_types_(classify_simplices(universe_)),
                       movable_edge_types_(classify_edges(universe_)),
                       attempted_moves_(std::make_tuple(0, 0, 0, 0, 0)),
@@ -57,7 +57,7 @@ class PachnerMoveTest : public Test {
   ///< Vertices in Delaunay triangulation
 };
 
-TEST_F(PachnerMoveTest, DelaunayDeepCopyCtor) {
+TEST_F(MoveManagerTest, DelaunayDeepCopyCtor) {
   // Print info on move/copy operation exception safety
   std::cout << std::boolalpha
     << "Delaunay alias is copy-assignable? "
@@ -121,7 +121,7 @@ TEST_F(PachnerMoveTest, DelaunayDeepCopyCtor) {
     << "Delaunay copy doesn't have the same number of spacelike edges.";
 }
 
-TEST_F(PachnerMoveTest, MakeA23MoveOnACopyAndSwap) {
+TEST_F(MoveManagerTest, MakeA23MoveOnACopyAndSwap) {
   EXPECT_TRUE(this->universe_->tds().is_valid())
     << "Constructed universe_ is invalid.";
 
@@ -195,7 +195,7 @@ TEST_F(PachnerMoveTest, MakeA23MoveOnACopyAndSwap) {
     << "make_23_move() changed the number of vertices.";
 }
 
-TEST_F(PachnerMoveTest, MakeA23PachnerMove) {
+TEST_F(MoveManagerTest, MakeA23MoveManager) {
   EXPECT_TRUE(this->universe_->tds().is_valid())
     << "Constructed universe_ is invalid.";
 
@@ -207,12 +207,12 @@ TEST_F(PachnerMoveTest, MakeA23PachnerMove) {
   std::cout << "Attempted (2,3) moves = " << std::get<0>(p.attempted_moves_)
             << std::endl;
 
-  // Move info from PachnerMove
+  // Move info from MoveManager
   universe_ = std::move(p.universe_);
   std::get<0>(attempted_moves_) += std::get<0>(p.attempted_moves_);
 
   EXPECT_TRUE(this->universe_->tds().is_valid())
-    << "PachnerMove(TWO_THREE) invalidated universe_.";
+    << "MoveManager(TWO_THREE) invalidated universe_.";
 
   // Re-populate with current data
   auto new_movable_simplex_types = classify_simplices(this->universe_);
@@ -234,28 +234,28 @@ TEST_F(PachnerMoveTest, MakeA23PachnerMove) {
             << this->universe_->number_of_vertices() << std::endl;
 
 EXPECT_THAT(std::get<0>(attempted_moves_), Ge(1))
-  << "PachnerMove(TWO_THREE) didn't record an attempted move.";
+  << "MoveManager(TWO_THREE) didn't record an attempted move.";
 
 EXPECT_THAT(std::get<1>(new_movable_simplex_types).size(),
   Eq(std::get<1>(movable_simplex_types_).size()+1))
-  << "PachnerMove(TWO_THREE) didn't add one and only one (2,2) simplex.";
+  << "MoveManager(TWO_THREE) didn't add one and only one (2,2) simplex.";
 
 EXPECT_THAT(std::get<0>(new_movable_simplex_types).size(),
   Eq(std::get<0>(movable_simplex_types_).size()))
-  << "PachnerMove(TWO_THREE) changed (3,1) simplices.";
+  << "MoveManager(TWO_THREE) changed (3,1) simplices.";
 
 EXPECT_THAT(std::get<2>(new_movable_simplex_types).size(),
   Eq(std::get<2>(movable_simplex_types_).size()))
-  << "PachnerMove(TWO_THREE) changed (1,3) simplices.";
+  << "MoveManager(TWO_THREE) changed (1,3) simplices.";
 
 EXPECT_THAT(new_movable_edge_types.first.size(),
   Eq(movable_edge_types_.first.size()+1))
-  << "PachnerMove(TWO_THREE) didn't add one and only one timelike edge.";
+  << "MoveManager(TWO_THREE) didn't add one and only one timelike edge.";
 
 EXPECT_THAT(new_movable_edge_types.second, Eq(movable_edge_types_.second))
-  << "PachnerMove(TWO_THREE) changed the number of spacelike edges.";
+  << "MoveManager(TWO_THREE) changed the number of spacelike edges.";
 
 EXPECT_THAT(this->universe_->number_of_vertices(),
   Eq(number_of_vertices_))
-  << "PachnerMove(TWO_THREE) changed the number of vertices.";
+  << "MoveManager(TWO_THREE) changed the number of vertices.";
 }

--- a/unittests/MoveManagerTest.cpp
+++ b/unittests/MoveManagerTest.cpp
@@ -51,7 +51,7 @@ class MoveManagerTest : public Test {
   ///< Movable (3,1), (2,2) and (1,3) simplices.
   std::pair<std::vector<Edge_tuple>, unsigned> movable_edge_types_;
   ///< Movable timelike and spacelike edges.
-  move_tuple attempted_moves_;
+  Move_tuple attempted_moves_;
   ///< A count of all attempted moves
   std::uintmax_t number_of_vertices_;
   ///< Vertices in Delaunay triangulation

--- a/unittests/S3ErgodicMovesTest.cpp
+++ b/unittests/S3ErgodicMovesTest.cpp
@@ -111,40 +111,6 @@ class MinimalErgodic26MoveTest : public S3ErgodicMoveTest {
   std::pair<std::vector<Point>, std::vector<std::uintmax_t>> causal_vertices;
 };
 
-// class Minimal62Test : public Minimal26Test {
-//  protected:
-//   virtual void SetUp() {
-//     // Manually create causal_vertices
-//     std::pair<std::vector<Point>, std::vector<unsigned>>
-//       causal_vertices(V, timevalue);
-//     // Manually insert
-//     insert_into_triangulation(universe_ptr, causal_vertices);
-//     // We have a (1,3) and (3,1) now use make_26_move() to create test case
-//     universe_ptr = std::move(make_26_move(universe_ptr,
-//                                           simplex_types,
-//                                           attempted_moves));
-//     // Now classify
-//     simplex_types = classify_simplices(universe_ptr);
-//     edge_types = classify_edges(universe_ptr);
-//     number_of_vertices_before = universe_ptr->number_of_vertices();
-//     N3_31_before = std::get<0>(simplex_types).size();
-//     N3_22_before = std::get<1>(simplex_types).size();
-//     N3_13_before = std::get<2>(simplex_types).size();
-//     V2_before = edge_types.first.size();
-//     std::cout << "Number of vertices before = " << number_of_vertices_before
-//               << std::endl;
-//     std::cout << "Number of (3,1) simplices before = " << N3_31_before
-//               << std::endl;
-//     std::cout << "Number of (2,2) simplices before = " << N3_22_before
-//               << std::endl;
-//     std::cout << "Number of (1,3) simplices before = " << N3_13_before
-//               << std::endl;
-//     std::cout << "Number of timelike edges before = " << V2_before
-//               << std::endl;
-//   }
-// };
-//
-//
 TEST_F(S3ErgodicMoveTest, MakeA23Move) {
   universe_ = std::move(make_23_move(universe_,
                                      movable_simplex_types_,
@@ -152,20 +118,19 @@ TEST_F(S3ErgodicMoveTest, MakeA23Move) {
   std::cout << "Attempted (2,3) moves = " << std::get<0>(attempted_moves_)
             << std::endl;
 
-  // Did we remove a (2,2) Cell_handle?
+  // (2,2) Cell_handle removed from the list of possible (2,3) move sites?
   EXPECT_THAT(std::get<1>(movable_simplex_types_).size(), Le(N3_22_before-1))
-    << "make_23_move didn't remove a (2,2) simplex vector element.";
+    << "(2,2) simplex not removed from movable_simplex_types_.";
 
-  // Did we record an attempted move?
   EXPECT_THAT(std::get<0>(attempted_moves_) +
               std::get<1>(movable_simplex_types_).size(), Eq(N3_22_before))
     << "Attempted (2,3) moves not recorded correctly.";
 
   EXPECT_THAT(std::get<0>(movable_simplex_types_).size(), Eq(N3_31_before))
-    << "make_23_move removed a (3,1) simplex vector element.";
+    << "(3,1) simplex removed from movable_simplex_types_.";
 
   EXPECT_THAT(std::get<2>(movable_simplex_types_).size(), Eq(N3_13_before))
-    << "make_23_move removed a (1,3) simplex vector element.";
+    << "(1,3) simplex removed from movable_simplex_types_.";
 
   // Now look at changes
   auto simplex_types = classify_simplices(universe_);
@@ -184,9 +149,6 @@ TEST_F(S3ErgodicMoveTest, MakeA23Move) {
   EXPECT_TRUE(fix_timeslices(universe_))
     << "Some simplices do not span exactly 1 timeslice.";
 
-  EXPECT_THAT(universe_->number_of_vertices(), Eq(vertices_before))
-    << "The number of vertices changed.";
-
   EXPECT_THAT(N3_31_after, Eq(N3_31_before))
     << "(3,1) simplices changed.";
 
@@ -195,59 +157,68 @@ TEST_F(S3ErgodicMoveTest, MakeA23Move) {
 
   EXPECT_THAT(N3_13_after, Eq(N3_13_before))
     << "(1,3) simplices changed.";
+
+  EXPECT_THAT(edge_types.first.size(), Eq(timelike_edges+1))
+    << "Timelike edges did not increase by 1.";
+
+  EXPECT_THAT(edge_types.second, Eq(spacelike_edges))
+    << "Spacelike edges changed.";
+
+  EXPECT_THAT(universe_->number_of_vertices(), Eq(vertices_before))
+    << "The number of vertices changed.";
 }
-//
-// TEST_F(S3ErgodicMoves, MakeA32Move) {
-//   universe_ptr = std::move(make_32_move(universe_ptr,
-//                                         edge_types,
-//                                         attempted_moves));
-//   // auto attempted_32_moves = std::get<1>(attempted_moves);
-//   std::cout << "Attempted (3,2) moves = " << std::get<1>(attempted_moves)
-//                                           << std::endl;
-//
-//   // Did we remove a timelike edge?
-//   EXPECT_THAT(edge_types.first.size(), Le(V2_before-1))
-//     << "make_32_move didn't remove a timelike edge vector element.";
-//
-//   // Did we record attempted (3,2) moves?
-//   EXPECT_THAT(std::get<1>(attempted_moves) + edge_types.first.size(),
-//               Eq(V2_before))
-//     << "Attempted (3,2) moves not recorded correctly.";
-//
-//   // Now look at changes
-//   simplex_types = classify_simplices(universe_ptr);
-//   auto N3_31_after = std::get<0>(simplex_types).size();
-//   auto N3_22_after = std::get<1>(simplex_types).size();
-//   auto N3_13_after = std::get<2>(simplex_types).size();
-//   edge_types = classify_edges(universe_ptr);
-//   auto V2_after = edge_types.first.size();
-//
-//   // We expect the triangulation to be valid, but not necessarily Delaunay
-//   EXPECT_TRUE(universe_ptr->tds().is_valid())
-//     << "Triangulation is invalid.";
-//
-//   EXPECT_THAT(universe_ptr->dimension(), Eq(3))
-//     << "Triangulation has wrong dimensionality.";
-//
-//   EXPECT_TRUE(fix_timeslices(universe_ptr))
-//     << "Some simplices do not span exactly 1 timeslice.";
-//
-//   EXPECT_THAT(universe_ptr->number_of_vertices(), Eq(number_of_vertices_before))
-//     << "The number of vertices changed.";
-//
-//   EXPECT_THAT(N3_31_after, Eq(N3_31_before))
-//     << "(3,1) simplices changed.";
-//
-//   EXPECT_THAT(N3_22_after, Eq(N3_22_before-1))
-//     << "(2,2) simplices did not decrease by 1.";
-//
-//   EXPECT_THAT(N3_13_after, Eq(N3_13_before))
-//     << "(1,3) simplices changed.";
-//
-//   EXPECT_THAT(V2_after, Eq(V2_before-1))
-//     << "The edge that was flipped wasn't removed.";
-// }
-//
+
+TEST_F(S3ErgodicMoveTest, MakeA32Move) {
+  universe_ = std::move(make_32_move(universe_,
+                                     movable_edge_types_,
+                                     attempted_moves_));
+  std::cout << "Attempted (3,2) moves = " << std::get<1>(attempted_moves_)
+                                          << std::endl;
+
+  // Timelike edge removed from the list of possible (3,2) move sites?
+  EXPECT_THAT(movable_edge_types_.first.size(), Le(timelike_edges-1))
+    << "Timelike edge not removed from movable_edge_types_.";
+
+  EXPECT_THAT(std::get<1>(attempted_moves_) + movable_edge_types_.first.size(),
+              Eq(timelike_edges))
+    << "Attempted (3,2) moves not recorded correctly.";
+
+  // Now look at changes
+  auto simplex_types = classify_simplices(universe_);
+  auto N3_31_after = std::get<0>(simplex_types).size();
+  auto N3_22_after = std::get<1>(simplex_types).size();
+  auto N3_13_after = std::get<2>(simplex_types).size();
+  auto edge_types = classify_edges(universe_);
+
+  // We expect the triangulation to be valid, but not necessarily Delaunay
+  EXPECT_TRUE(universe_->tds().is_valid())
+    << "Triangulation is invalid.";
+
+  EXPECT_THAT(universe_->dimension(), Eq(3))
+    << "Triangulation has wrong dimensionality.";
+
+  EXPECT_TRUE(fix_timeslices(universe_))
+    << "Some simplices do not span exactly 1 timeslice.";
+
+  EXPECT_THAT(N3_31_after, Eq(N3_31_before))
+    << "(3,1) simplices changed.";
+
+  EXPECT_THAT(N3_22_after, Eq(N3_22_before-1))
+    << "(2,2) simplices did not decrease by 1.";
+
+  EXPECT_THAT(N3_13_after, Eq(N3_13_before))
+    << "(1,3) simplices changed.";
+
+  EXPECT_THAT(edge_types.first.size(), Eq(timelike_edges-1))
+    << "Timelike edges did not decrease by 1.";
+
+  EXPECT_THAT(edge_types.second, Eq(spacelike_edges))
+    << "Spacelike edges changed.";
+
+  EXPECT_THAT(universe_->number_of_vertices(), Eq(vertices_before))
+    << "The number of vertices changed.";
+}
+
 TEST_F(MinimalErgodic26MoveTest, MakeA26Move) {
   universe_ = std::move(make_26_move(universe_,
                                      movable_simplex_types_,
@@ -292,6 +263,22 @@ TEST_F(S3ErgodicMoveTest, MakeA26Move) {
   universe_ = std::move(make_26_move(universe_,
                                      movable_simplex_types_,
                                      attempted_moves_));
+  std::cout << "Attempted (2,6) moves = " << std::get<2>(attempted_moves_)
+                                          << std::endl;
+
+  // (1,3) Cell_handle removed from the list of possible (2,6) move sites?
+  EXPECT_THAT(std::get<2>(movable_simplex_types_).size(), Le(N3_13_before-1))
+    << "(1,3) simplex not removed from movable_simplex_types_.";
+
+  EXPECT_THAT(std::get<2>(attempted_moves_) +
+             std::get<2>(movable_simplex_types_).size(), Eq(N3_13_before))
+    << "Attempted (2,6) moves not recorded correctly.";
+
+  EXPECT_THAT(std::get<0>(movable_simplex_types_).size(), Eq(N3_31_before))
+    << "(3,1) simplex removed from movable_simplex_types_.";
+
+  EXPECT_THAT(std::get<1>(movable_simplex_types_).size(), Eq(N3_22_before))
+    << "(2,2) simplex removed from movable_simplex_types_.";
 
   // Now look at changes
   auto simplex_types = classify_simplices(universe_);
@@ -299,7 +286,7 @@ TEST_F(S3ErgodicMoveTest, MakeA26Move) {
   auto N3_22_after = std::get<1>(simplex_types).size();
   auto N3_13_after = std::get<2>(simplex_types).size();
   auto edge_types = classify_edges(universe_);
-//
+
   EXPECT_TRUE(universe_->tds().is_valid(true))
     << "Triangulation is invalid.";
 
@@ -327,37 +314,3 @@ TEST_F(S3ErgodicMoveTest, MakeA26Move) {
   EXPECT_THAT(universe_->number_of_vertices(), Eq(vertices_before+1))
     << "A vertex was not added to the triangulation.";
 }
-
-// TEST_F(S3ErgodicMoves, DISABLED_MakeA62Move) {
-//   universe_ptr = std::move(make_62_move(universe_ptr,
-//                                         edge_types,
-//                                         attempted_moves));
-//
-//   // Now look at changes
-//   simplex_types = classify_simplices(universe_ptr);
-//   auto N3_31_after = std::get<0>(simplex_types).size();
-//   auto N3_22_after = std::get<1>(simplex_types).size();
-//   auto N3_13_after = std::get<2>(simplex_types).size();
-//
-//   EXPECT_TRUE(universe_ptr->tds().is_valid(true))
-//     << "Triangulation is invalid.";
-//
-//   EXPECT_THAT(universe_ptr->dimension(), Eq(3))
-//     << "Triangulation has wrong dimensionality.";
-//
-//   EXPECT_TRUE(fix_timeslices(universe_ptr))
-//     << "Some simplices do not span exactly 1 timeslice.";
-//
-//   EXPECT_THAT(universe_ptr->number_of_vertices(),
-//               Eq(number_of_vertices_before-1))
-//     << "A vertex was not subtracted from the triangulation.";
-//
-//   EXPECT_THAT(N3_31_after, Eq(N3_31_before-2))
-//     << "(3,1) simplices did not decrease by 2.";
-//
-//   EXPECT_THAT(N3_22_after, Eq(N3_22_before))
-//     << "(2,2) simplices changed.";
-//
-//   EXPECT_THAT(N3_13_after, Eq(N3_13_before-2))
-//     << "(1,3) simplices did not decrease by 2.";
-// }

--- a/unittests/S3ErgodicMovesTest.cpp
+++ b/unittests/S3ErgodicMovesTest.cpp
@@ -28,6 +28,14 @@ class S3ErgodicMoveTest : public Test {
                         attempted_moves_(std::make_tuple(0, 0, 0, 0, 0)),
                         number_of_vertices_(universe_->number_of_vertices()) {}
 
+  // explicit S3ErgodicMoveTest(Causal_vertices causal_vertices) {
+  //   insert_into_triangulation(universe_, causal_vertices);
+  //   movable_edge_types_ = classify_edges(universe_);
+  //   attempted_moves_ = std::make_tuple(0, 0, 0, 0, 0);
+  //   number_of_vertices_ = universe_->number_of_vertices();
+  // }
+  // Short circuit base class ctor
+  explicit S3ErgodicMoveTest(bool Test) {}
   // template <typename T1,typename T2, typename T3, typename T4>
   // S3ErgodicMoveTest(T1&& args1, T2&& args2, T3&& args3, T4&& args4 :
   //                       universe_(std::move(make_triangulation(6400, 17))),
@@ -67,8 +75,9 @@ class S3ErgodicMoveTest : public Test {
   //   std::cout << "Number of timelike edges before = " << V2_before
   //             << std::endl;
   }
-
-  std::unique_ptr<Delaunay> universe_;
+  Delaunay triangulation;
+  std::unique_ptr<Delaunay>
+    universe_ = std::make_unique<Delaunay>(triangulation);
   ///< Unique pointer to the Delaunay triangulation.
   std::tuple<std::vector<Cell_handle>,
              std::vector<Cell_handle>,
@@ -76,7 +85,7 @@ class S3ErgodicMoveTest : public Test {
   ///< Movable (3,1), (2,2), and (1,3) simplices.
   std::pair<std::vector<Edge_tuple>, std::uintmax_t> movable_edge_types_;
   ///< Movable timelike and spacelike edges.
-  move_tuple attempted_moves_;
+  Move_tuple attempted_moves_;
   ///< A count of all attempted moves.
   std::uintmax_t number_of_vertices_;
   ///< Vertices in Delaunay triangulation.
@@ -97,25 +106,31 @@ class S3ErgodicMoveTest : public Test {
   // unsigned N3_22_before{0};
   // unsigned N3_13_before{0};
   // unsigned V2_before{0};
-  // move_tuple attempted_moves;
+  // Move_tuple attempted_moves;
 };
 
 class Minimal26Test : public S3ErgodicMoveTest {
  protected:
-  Minimal26Test() // : causal_vertices(std::make_pair(V, timevalue)),
+  Minimal26Test() : S3ErgodicMoveTest(true)
+                    //S3ErgodicMoveTest(std::make_pair(V, timevalue))
+                    // : causal_vertices(std::make_pair(V, timevalue)),
                     //movable_simplex_types_(classify_simplices(universe_)),
                     //movable_edge_types_(classify_edges(universe_)),
                     //attempted_moves_(std::make_tuple(0, 0, 0, 0, 0)),
                     //number_of_vertices_(universe_->number_of_vertices())
     {
       // Manually insert
+      // S3ErgodicMoveTest(std::make_pair(V, timevalue));
       causal_vertices = std::make_pair(V, timevalue);
       insert_into_triangulation(universe_, causal_vertices);
+      movable_simplex_types_ = classify_simplices(universe_);
       movable_edge_types_ = classify_edges(universe_);
       attempted_moves_ = std::make_tuple(0, 0, 0, 0, 0);
       number_of_vertices_ = universe_->number_of_vertices();
-    }
-  // virtual void SetUp() {
+}
+  virtual void SetUp() {
+    S3ErgodicMoveTest::SetUp();
+    // S3ErgodicMoveTest(std::make_pair(V, timevalue));
   //   // Manually create causal_vertices
   //   std::pair<std::vector<Point>, std::vector<unsigned>>
   //     causal_vertices(V, timevalue);
@@ -138,7 +153,7 @@ class Minimal26Test : public S3ErgodicMoveTest {
   //             << std::endl;
   //   std::cout << "Number of timelike edges before = " << V2_before
   //             << std::endl;
-  // }
+  }
   std::vector<Delaunay::Point> V {
     Delaunay::Point(0, 1, 0),
     Delaunay::Point(0, 0, 1),

--- a/unittests/S3ErgodicMovesTest.cpp
+++ b/unittests/S3ErgodicMovesTest.cpp
@@ -21,12 +21,19 @@
 using namespace testing;  // NOLINT
 
 class S3ErgodicMoveTest : public Test {
- protected:
+ public:
   S3ErgodicMoveTest() : universe_(std::move(make_triangulation(6400, 17))),
                         movable_simplex_types_(classify_simplices(universe_)),
                         movable_edge_types_(classify_edges(universe_)),
                         attempted_moves_(std::make_tuple(0, 0, 0, 0, 0)),
                         number_of_vertices_(universe_->number_of_vertices()) {}
+
+  // template <typename T1,typename T2, typename T3, typename T4>
+  // S3ErgodicMoveTest(T1&& args1, T2&& args2, T3&& args3, T4&& args4 :
+  //                       universe_(std::move(make_triangulation(6400, 17))),
+  //                       movable_simplex_types_(classify_simplices(args1)),
+  //                       movable_edge_types_(classify_edges(universe_))
+
   virtual void SetUp() {
     // Print ctor-initialized values
     std::cout << "(3,1) simplices: "
@@ -93,14 +100,21 @@ class S3ErgodicMoveTest : public Test {
   // move_tuple attempted_moves;
 };
 
-// class Minimal26Test : public S3ErgodicMoveTest {
-//  protected:
-//    Minimal26Test() : universe_(std::move(insert_into_triangulation(
-//                                universe_, causal_vertices))),
-//                      movable_simplex_types_(classify_simplices(universe_)),
-//                      movable_edge_types_(classify_edges(universe_)),
-//                      attempted_moves_(std::make_tuple(0, 0, 0, 0, 0)),
-//                      number_of_vertices_(universe_->number_of_vertices()) {}
+class Minimal26Test : public S3ErgodicMoveTest {
+ protected:
+  Minimal26Test() // : causal_vertices(std::make_pair(V, timevalue)),
+                    //movable_simplex_types_(classify_simplices(universe_)),
+                    //movable_edge_types_(classify_edges(universe_)),
+                    //attempted_moves_(std::make_tuple(0, 0, 0, 0, 0)),
+                    //number_of_vertices_(universe_->number_of_vertices())
+    {
+      // Manually insert
+      causal_vertices = std::make_pair(V, timevalue);
+      insert_into_triangulation(universe_, causal_vertices);
+      movable_edge_types_ = classify_edges(universe_);
+      attempted_moves_ = std::make_tuple(0, 0, 0, 0, 0);
+      number_of_vertices_ = universe_->number_of_vertices();
+    }
   // virtual void SetUp() {
   //   // Manually create causal_vertices
   //   std::pair<std::vector<Point>, std::vector<unsigned>>
@@ -125,16 +139,15 @@ class S3ErgodicMoveTest : public Test {
   //   std::cout << "Number of timelike edges before = " << V2_before
   //             << std::endl;
   // }
-//   std::vector<Delaunay::Point> V {
-//     Delaunay::Point(0, 1, 0),
-//     Delaunay::Point(0, 0, 1),
-//     Delaunay::Point(1, 1, 1),
-//     Delaunay::Point(-1, 1, 1),
-//     Delaunay::Point(0, 0, 2)};
-//   std::vector<std::uintmax_t> timevalue {1, 2, 2, 2, 3};
-//   std::pair<std::vector<Point>, std::vector<std::uintmax_t>>
-//     causal_vertices{V, timevalue};
-// };
+  std::vector<Delaunay::Point> V {
+    Delaunay::Point(0, 1, 0),
+    Delaunay::Point(0, 0, 1),
+    Delaunay::Point(1, 1, 1),
+    Delaunay::Point(-1, 1, 1),
+    Delaunay::Point(0, 0, 2)};
+  std::vector<std::uintmax_t> timevalue {1, 2, 2, 2, 3};
+  std::pair<std::vector<Point>, std::vector<std::uintmax_t>> causal_vertices;
+};
 
 // class Minimal62Test : public Minimal26Test {
 //  protected:
@@ -272,25 +285,25 @@ class S3ErgodicMoveTest : public Test {
 //     << "The edge that was flipped wasn't removed.";
 // }
 //
-// TEST_F(Minimal26Test, MakeA26Move) {
-//   universe_ptr = std::move(make_26_move(universe_ptr,
-//                                         simplex_types,
-//                                         attempted_moves));
+TEST_F(Minimal26Test, MakeA26Move) {
+  universe_ = std::move(make_26_move(universe_,
+                                     movable_simplex_types_,
+                                     attempted_moves_));
+
+  // Now look at changes
+  auto simplex_types = classify_simplices(universe_);
+  auto N3_31_after = std::get<0>(simplex_types).size();
+  auto N3_22_after = std::get<1>(simplex_types).size();
+  auto N3_13_after = std::get<2>(simplex_types).size();
 //
-//   // Now look at changes
-//   simplex_types = classify_simplices(universe_ptr);
-//   auto N3_31_after = std::get<0>(simplex_types).size();
-//   auto N3_22_after = std::get<1>(simplex_types).size();
-//   auto N3_13_after = std::get<2>(simplex_types).size();
-//
-//   EXPECT_TRUE(universe_ptr->tds().is_valid(true))
-//     << "Triangulation is invalid.";
-//
-//   EXPECT_THAT(universe_ptr->dimension(), Eq(3))
-//     << "Triangulation has wrong dimensionality.";
-//
-//   EXPECT_TRUE(fix_timeslices(universe_ptr))
-//     << "Some simplices do not span exactly 1 timeslice.";
+  EXPECT_TRUE(universe_->tds().is_valid(true))
+    << "Triangulation is invalid.";
+
+  EXPECT_THAT(universe_->dimension(), Eq(3))
+    << "Triangulation has wrong dimensionality.";
+
+  EXPECT_TRUE(fix_timeslices(universe_))
+    << "Some simplices do not span exactly 1 timeslice.";
 //
 //   EXPECT_THAT(universe_ptr->number_of_vertices(),
 //               Eq(number_of_vertices_before+1))
@@ -304,7 +317,7 @@ class S3ErgodicMoveTest : public Test {
 //
 //   EXPECT_THAT(N3_13_after, Eq(N3_13_before+2))
 //     << "(1,3) simplices did not increase by 2.";
-// }
+}
 //
 // TEST_F(S3ErgodicMoves, MakeA26Move) {
 //   universe_ptr = std::move(make_26_move(universe_ptr,

--- a/unittests/S3ErgodicMovesTest.cpp
+++ b/unittests/S3ErgodicMovesTest.cpp
@@ -28,22 +28,12 @@ class S3ErgodicMoveTest : public Test {
                         attempted_moves_(std::make_tuple(0, 0, 0, 0, 0)),
                         number_of_vertices_(universe_->number_of_vertices()) {}
 
-  // explicit S3ErgodicMoveTest(Causal_vertices causal_vertices) {
-  //   insert_into_triangulation(universe_, causal_vertices);
-  //   movable_edge_types_ = classify_edges(universe_);
-  //   attempted_moves_ = std::make_tuple(0, 0, 0, 0, 0);
-  //   number_of_vertices_ = universe_->number_of_vertices();
-  // }
-  // Short circuit base class ctor
+  // No initialization by base class ctor
   explicit S3ErgodicMoveTest(bool Test) {}
-  // template <typename T1,typename T2, typename T3, typename T4>
-  // S3ErgodicMoveTest(T1&& args1, T2&& args2, T3&& args3, T4&& args4 :
-  //                       universe_(std::move(make_triangulation(6400, 17))),
-  //                       movable_simplex_types_(classify_simplices(args1)),
-  //                       movable_edge_types_(classify_edges(universe_))
 
   virtual void SetUp() {
     // Print ctor-initialized values
+    std::cout << "Initial Triangulation ..." << std::endl;
     std::cout << "(3,1) simplices: "
               << std::get<0>(movable_simplex_types_).size() << std::endl;
     std::cout << "(2,2) simplices: "
@@ -56,26 +46,18 @@ class S3ErgodicMoveTest : public Test {
               << movable_edge_types_.second << std::endl;
     std::cout << "Vertices: "
               << number_of_vertices_ << std::endl;
-  //   universe_ptr = std::move(make_triangulation(simplices, timeslices));
-  //   simplex_types = classify_simplices(universe_ptr);
-  //   edge_types = classify_edges(universe_ptr);
-  //   number_of_vertices_before = universe_ptr->number_of_vertices();
-  //   N3_31_before = std::get<0>(simplex_types).size();
-  //   N3_22_before = std::get<1>(simplex_types).size();
-  //   N3_13_before = std::get<2>(simplex_types).size();
-  //   V2_before = edge_types.first.size();
-  //   std::cout << "Number of vertices before = " << number_of_vertices_before
-  //             << std::endl;
-  //   std::cout << "Number of (3,1) simplices before = " << N3_31_before
-  //             << std::endl;
-  //   std::cout << "Number of (2,2) simplices before = " << N3_22_before
-  //             << std::endl;
-  //   std::cout << "Number of (1,3) simplices before = " << N3_13_before
-  //             << std::endl;
-  //   std::cout << "Number of timelike edges before = " << V2_before
-  //             << std::endl;
+
+    // Initial values for comparison tests
+    N3_31_before = std::get<0>(movable_simplex_types_).size();
+    N3_22_before = std::get<1>(movable_simplex_types_).size();
+    N3_13_before = std::get<2>(movable_simplex_types_).size();
+    timelike_edges = movable_edge_types_.first.size();
+    spacelike_edges = movable_edge_types_.second;
+    vertices_before = number_of_vertices_;
   }
+
   Delaunay triangulation;
+  ///< Delaunay triangulation
   std::unique_ptr<Delaunay>
     universe_ = std::make_unique<Delaunay>(triangulation);
   ///< Unique pointer to the Delaunay triangulation.
@@ -89,71 +71,36 @@ class S3ErgodicMoveTest : public Test {
   ///< A count of all attempted moves.
   std::uintmax_t number_of_vertices_;
   ///< Vertices in Delaunay triangulation.
-  // Delaunay universe;
-  // std::unique_ptr<decltype(universe)>
-  //   universe_ptr = std::make_unique<decltype(universe)>(universe);
-  // static constexpr auto simplices = static_cast<unsigned>(6400);
-  // static constexpr auto timeslices = static_cast<unsigned>(16);
-  // std::tuple<std::vector<Cell_handle>,
-  //            std::vector<Cell_handle>,
-  //            std::vector<Cell_handle>> simplex_types;
-  // // std::tuple<std::vector<Cell_handle>,
-  // //            std::vector<Cell_handle>,
-  // //            std::vector<Cell_handle>> movable_simplex_types;
-  // std::pair<std::vector<Edge_tuple>, unsigned> edge_types;
-  // unsigned number_of_vertices_before{0};
-  // unsigned N3_31_before{0};
-  // unsigned N3_22_before{0};
-  // unsigned N3_13_before{0};
-  // unsigned V2_before{0};
-  // Move_tuple attempted_moves;
+  std::uintmax_t N3_31_before{0};
+  ///< Initial number of (3,1) simplices
+  std::uintmax_t N3_22_before{0};
+  ///< Initial number of (2,2) simplices
+  std::uintmax_t N3_13_before{0};
+  ///< Initial number of (1,3) simplices
+  std::uintmax_t timelike_edges{0};
+  ///< Initial number of timelike edges
+  std::uintmax_t spacelike_edges{0};
+  ///< Initial number of spacelike edges
+  std::uintmax_t vertices_before{0};
+  ///< Initial number of vertices
 };
 
-class Minimal26Test : public S3ErgodicMoveTest {
+class MinimalErgodic26MoveTest : public S3ErgodicMoveTest {
  protected:
-  Minimal26Test() : S3ErgodicMoveTest(true)
-                    //S3ErgodicMoveTest(std::make_pair(V, timevalue))
-                    // : causal_vertices(std::make_pair(V, timevalue)),
-                    //movable_simplex_types_(classify_simplices(universe_)),
-                    //movable_edge_types_(classify_edges(universe_)),
-                    //attempted_moves_(std::make_tuple(0, 0, 0, 0, 0)),
-                    //number_of_vertices_(universe_->number_of_vertices())
-    {
-      // Manually insert
-      // S3ErgodicMoveTest(std::make_pair(V, timevalue));
-      causal_vertices = std::make_pair(V, timevalue);
-      insert_into_triangulation(universe_, causal_vertices);
-      movable_simplex_types_ = classify_simplices(universe_);
-      movable_edge_types_ = classify_edges(universe_);
-      attempted_moves_ = std::make_tuple(0, 0, 0, 0, 0);
-      number_of_vertices_ = universe_->number_of_vertices();
-}
+  MinimalErgodic26MoveTest() : S3ErgodicMoveTest(true) {
+    // Manually insert
+    causal_vertices = std::make_pair(V, timevalue);
+    insert_into_triangulation(universe_, causal_vertices);
+    movable_simplex_types_ = classify_simplices(universe_);
+    movable_edge_types_ = classify_edges(universe_);
+    attempted_moves_ = std::make_tuple(0, 0, 0, 0, 0);
+    number_of_vertices_ = universe_->number_of_vertices();
+  }
+
   virtual void SetUp() {
     S3ErgodicMoveTest::SetUp();
-    // S3ErgodicMoveTest(std::make_pair(V, timevalue));
-  //   // Manually create causal_vertices
-  //   std::pair<std::vector<Point>, std::vector<unsigned>>
-  //     causal_vertices(V, timevalue);
-  //   // Manually insert
-  //   insert_into_triangulation(universe_ptr, causal_vertices);
-  //   simplex_types = classify_simplices(universe_ptr);
-  //   edge_types = classify_edges(universe_ptr);
-  //   number_of_vertices_before = universe_ptr->number_of_vertices();
-  //   N3_31_before = std::get<0>(simplex_types).size();
-  //   N3_22_before = std::get<1>(simplex_types).size();
-  //   N3_13_before = std::get<2>(simplex_types).size();
-  //   V2_before = edge_types.first.size();
-  //   std::cout << "Number of vertices before = " << number_of_vertices_before
-  //             << std::endl;
-  //   std::cout << "Number of (3,1) simplices before = " << N3_31_before
-  //             << std::endl;
-  //   std::cout << "Number of (2,2) simplices before = " << N3_22_before
-  //             << std::endl;
-  //   std::cout << "Number of (1,3) simplices before = " << N3_13_before
-  //             << std::endl;
-  //   std::cout << "Number of timelike edges before = " << V2_before
-  //             << std::endl;
   }
+
   std::vector<Delaunay::Point> V {
     Delaunay::Point(0, 1, 0),
     Delaunay::Point(0, 0, 1),
@@ -198,56 +145,57 @@ class Minimal26Test : public S3ErgodicMoveTest {
 // };
 //
 //
-// TEST_F(S3ErgodicMoves, MakeA23Move) {
-//   universe_ptr = std::move(make_23_move(universe_ptr,
-//                                         simplex_types,
-//                                         attempted_moves));
-//   std::cout << "Attempted (2,3) moves = " << std::get<0>(attempted_moves)
-//             << std::endl;
-//
-//   // Did we remove a (2,2) Cell_handle?
-//   EXPECT_THAT(std::get<1>(simplex_types).size(), Le(N3_22_before-1))
-//     << "make_23_move didn't remove a (2,2) simplex vector element.";
-//
-//   // Did we record an attempted move?
-//   EXPECT_THAT(std::get<0>(attempted_moves) +
-//               std::get<1>(simplex_types).size(), Eq(N3_22_before))
-//     << "Attempted (2,3) moves not recorded correctly.";
-//
-//   EXPECT_THAT(std::get<0>(simplex_types).size(), Eq(N3_31_before))
-//     << "make_23_move removed a (3,1) simplex vector element.";
-//
-//   EXPECT_THAT(std::get<2>(simplex_types).size(), Eq(N3_13_before))
-//     << "make_23_move removed a (1,3) simplex vector element.";
-//
-//   // Now look at changes
-//   simplex_types = classify_simplices(universe_ptr);
-//   auto N3_31_after = std::get<0>(simplex_types).size();
-//   auto N3_22_after = std::get<1>(simplex_types).size();
-//   auto N3_13_after = std::get<2>(simplex_types).size();
-//
-//   // We expect the triangulation to be valid, but not necessarily Delaunay
-//   EXPECT_TRUE(universe_ptr->tds().is_valid())
-//     << "Triangulation is invalid.";
-//
-//   EXPECT_THAT(universe_ptr->dimension(), Eq(3))
-//     << "Triangulation has wrong dimensionality.";
-//
-//   EXPECT_TRUE(fix_timeslices(universe_ptr))
-//     << "Some simplices do not span exactly 1 timeslice.";
-//
-//   EXPECT_THAT(universe_ptr->number_of_vertices(), Eq(number_of_vertices_before))
-//     << "The number of vertices changed.";
-//
-//   EXPECT_THAT(N3_31_after, Eq(N3_31_before))
-//     << "(3,1) simplices changed.";
-//
-//   EXPECT_THAT(N3_22_after, Eq(N3_22_before+1))
-//     << "(2,2) simplices did not increase by 1.";
-//
-//   EXPECT_THAT(N3_13_after, Eq(N3_13_before))
-//     << "(1,3) simplices changed.";
-// }
+TEST_F(S3ErgodicMoveTest, MakeA23Move) {
+  universe_ = std::move(make_23_move(universe_,
+                                     movable_simplex_types_,
+                                     attempted_moves_));
+  std::cout << "Attempted (2,3) moves = " << std::get<0>(attempted_moves_)
+            << std::endl;
+
+  // Did we remove a (2,2) Cell_handle?
+  EXPECT_THAT(std::get<1>(movable_simplex_types_).size(), Le(N3_22_before-1))
+    << "make_23_move didn't remove a (2,2) simplex vector element.";
+
+  // Did we record an attempted move?
+  EXPECT_THAT(std::get<0>(attempted_moves_) +
+              std::get<1>(movable_simplex_types_).size(), Eq(N3_22_before))
+    << "Attempted (2,3) moves not recorded correctly.";
+
+  EXPECT_THAT(std::get<0>(movable_simplex_types_).size(), Eq(N3_31_before))
+    << "make_23_move removed a (3,1) simplex vector element.";
+
+  EXPECT_THAT(std::get<2>(movable_simplex_types_).size(), Eq(N3_13_before))
+    << "make_23_move removed a (1,3) simplex vector element.";
+
+  // Now look at changes
+  auto simplex_types = classify_simplices(universe_);
+  auto N3_31_after = std::get<0>(simplex_types).size();
+  auto N3_22_after = std::get<1>(simplex_types).size();
+  auto N3_13_after = std::get<2>(simplex_types).size();
+  auto edge_types = classify_edges(universe_);
+
+  // We expect the triangulation to be valid, but not necessarily Delaunay
+  EXPECT_TRUE(universe_->tds().is_valid())
+    << "Triangulation is invalid.";
+
+  EXPECT_THAT(universe_->dimension(), Eq(3))
+    << "Triangulation has wrong dimensionality.";
+
+  EXPECT_TRUE(fix_timeslices(universe_))
+    << "Some simplices do not span exactly 1 timeslice.";
+
+  EXPECT_THAT(universe_->number_of_vertices(), Eq(vertices_before))
+    << "The number of vertices changed.";
+
+  EXPECT_THAT(N3_31_after, Eq(N3_31_before))
+    << "(3,1) simplices changed.";
+
+  EXPECT_THAT(N3_22_after, Eq(N3_22_before+1))
+    << "(2,2) simplices did not increase by 1.";
+
+  EXPECT_THAT(N3_13_after, Eq(N3_13_before))
+    << "(1,3) simplices changed.";
+}
 //
 // TEST_F(S3ErgodicMoves, MakeA32Move) {
 //   universe_ptr = std::move(make_32_move(universe_ptr,
@@ -300,7 +248,7 @@ class Minimal26Test : public S3ErgodicMoveTest {
 //     << "The edge that was flipped wasn't removed.";
 // }
 //
-TEST_F(Minimal26Test, MakeA26Move) {
+TEST_F(MinimalErgodic26MoveTest, MakeA26Move) {
   universe_ = std::move(make_26_move(universe_,
                                      movable_simplex_types_,
                                      attempted_moves_));
@@ -310,6 +258,47 @@ TEST_F(Minimal26Test, MakeA26Move) {
   auto N3_31_after = std::get<0>(simplex_types).size();
   auto N3_22_after = std::get<1>(simplex_types).size();
   auto N3_13_after = std::get<2>(simplex_types).size();
+  auto edge_types = classify_edges(universe_);
+
+  EXPECT_TRUE(universe_->tds().is_valid(true))
+    << "Triangulation is invalid.";
+
+  EXPECT_THAT(universe_->dimension(), Eq(3))
+    << "Triangulation has wrong dimensionality.";
+
+  EXPECT_TRUE(fix_timeslices(universe_))
+    << "Some simplices do not span exactly 1 timeslice.";
+
+  EXPECT_THAT(N3_31_after, Eq(N3_31_before+2))
+    << "(3,1) simplices did not increase by 2.";
+
+  EXPECT_THAT(N3_22_after, Eq(N3_22_before))
+    << "(2,2) simplices changed.";
+
+  EXPECT_THAT(N3_13_after, Eq(N3_13_before+2))
+    << "(1,3) simplices did not increase by 2.";
+
+  EXPECT_THAT(edge_types.first.size(), Eq(timelike_edges+2))
+    << "Timelike edges did not increase by 2.";
+
+  EXPECT_THAT(edge_types.second, Eq(spacelike_edges+3))
+    << "Spacelike edges did not increase by 3.";
+
+  EXPECT_THAT(universe_->number_of_vertices(), Eq(vertices_before+1))
+    << "A vertex was not added to the triangulation.";
+}
+
+TEST_F(S3ErgodicMoveTest, MakeA26Move) {
+  universe_ = std::move(make_26_move(universe_,
+                                     movable_simplex_types_,
+                                     attempted_moves_));
+
+  // Now look at changes
+  auto simplex_types = classify_simplices(universe_);
+  auto N3_31_after = std::get<0>(simplex_types).size();
+  auto N3_22_after = std::get<1>(simplex_types).size();
+  auto N3_13_after = std::get<2>(simplex_types).size();
+  auto edge_types = classify_edges(universe_);
 //
   EXPECT_TRUE(universe_->tds().is_valid(true))
     << "Triangulation is invalid.";
@@ -319,55 +308,26 @@ TEST_F(Minimal26Test, MakeA26Move) {
 
   EXPECT_TRUE(fix_timeslices(universe_))
     << "Some simplices do not span exactly 1 timeslice.";
-//
-//   EXPECT_THAT(universe_ptr->number_of_vertices(),
-//               Eq(number_of_vertices_before+1))
-//     << "A vertex was not added to the triangulation.";
-//
-//   EXPECT_THAT(N3_31_after, Eq(N3_31_before+2))
-//     << "(3,1) simplices did not increase by 2.";
-//
-//   EXPECT_THAT(N3_22_after, Eq(N3_22_before))
-//     << "(2,2) simplices changed.";
-//
-//   EXPECT_THAT(N3_13_after, Eq(N3_13_before+2))
-//     << "(1,3) simplices did not increase by 2.";
+
+  EXPECT_THAT(N3_31_after, Eq(N3_31_before+2))
+    << "(3,1) simplices did not increase by 2.";
+
+  EXPECT_THAT(N3_22_after, Eq(N3_22_before))
+    << "(2,2) simplices changed.";
+
+  EXPECT_THAT(N3_13_after, Eq(N3_13_before+2))
+    << "(1,3) simplices did not increase by 2.";
+
+  EXPECT_THAT(edge_types.first.size(), Eq(timelike_edges+2))
+    << "Timelike edges did not increase by 2.";
+
+  EXPECT_THAT(edge_types.second, Eq(spacelike_edges+3))
+    << "Spacelike edges did not increase by 3.";
+
+  EXPECT_THAT(universe_->number_of_vertices(), Eq(vertices_before+1))
+    << "A vertex was not added to the triangulation.";
 }
-//
-// TEST_F(S3ErgodicMoves, MakeA26Move) {
-//   universe_ptr = std::move(make_26_move(universe_ptr,
-//                                         simplex_types,
-//                                         attempted_moves));
-//
-//   // Now look at changes
-//   simplex_types = classify_simplices(universe_ptr);
-//   auto N3_31_after = std::get<0>(simplex_types).size();
-//   auto N3_22_after = std::get<1>(simplex_types).size();
-//   auto N3_13_after = std::get<2>(simplex_types).size();
-//
-//   EXPECT_TRUE(universe_ptr->tds().is_valid(true))
-//     << "Triangulation is invalid.";
-//
-//   EXPECT_THAT(universe_ptr->dimension(), Eq(3))
-//     << "Triangulation has wrong dimensionality.";
-//
-//   EXPECT_TRUE(fix_timeslices(universe_ptr))
-//     << "Some simplices do not span exactly 1 timeslice.";
-//
-//   EXPECT_THAT(universe_ptr->number_of_vertices(),
-//               Eq(number_of_vertices_before+1))
-//     << "A vertex was not added to the triangulation.";
-//
-//   EXPECT_THAT(N3_31_after, Eq(N3_31_before+2))
-//     << "(3,1) simplices did not increase by 2.";
-//
-//   EXPECT_THAT(N3_22_after, Eq(N3_22_before))
-//     << "(2,2) simplices changed.";
-//
-//   EXPECT_THAT(N3_13_after, Eq(N3_13_before+2))
-//     << "(1,3) simplices did not increase by 2.";
-// }
-//
+
 // TEST_F(S3ErgodicMoves, DISABLED_MakeA62Move) {
 //   universe_ptr = std::move(make_62_move(universe_ptr,
 //                                         edge_types,

--- a/unittests/S3ErgodicMovesTest.cpp
+++ b/unittests/S3ErgodicMovesTest.cpp
@@ -16,321 +16,360 @@
 #include <utility>
 
 #include "gmock/gmock.h"
-#include "S3ErgodicMoves.h"
+#include "src/S3ErgodicMoves.h"
 
 using namespace testing;  // NOLINT
 
-class S3ErgodicMoves : public Test {
+class S3ErgodicMoveTest : public Test {
  protected:
+  S3ErgodicMoveTest() : universe_(std::move(make_triangulation(6400, 17))),
+                        movable_simplex_types_(classify_simplices(universe_)),
+                        movable_edge_types_(classify_edges(universe_)),
+                        attempted_moves_(std::make_tuple(0, 0, 0, 0, 0)),
+                        number_of_vertices_(universe_->number_of_vertices()) {}
   virtual void SetUp() {
-    universe_ptr = std::move(make_triangulation(simplices, timeslices));
-    simplex_types = classify_simplices(universe_ptr);
-    edge_types = classify_edges(universe_ptr);
-    number_of_vertices_before = universe_ptr->number_of_vertices();
-    N3_31_before = std::get<0>(simplex_types).size();
-    N3_22_before = std::get<1>(simplex_types).size();
-    N3_13_before = std::get<2>(simplex_types).size();
-    V2_before = edge_types.first.size();
-    std::cout << "Number of vertices before = " << number_of_vertices_before
-              << std::endl;
-    std::cout << "Number of (3,1) simplices before = " << N3_31_before
-              << std::endl;
-    std::cout << "Number of (2,2) simplices before = " << N3_22_before
-              << std::endl;
-    std::cout << "Number of (1,3) simplices before = " << N3_13_before
-              << std::endl;
-    std::cout << "Number of timelike edges before = " << V2_before
-              << std::endl;
+    // Print ctor-initialized values
+    std::cout << "(3,1) simplices: "
+              << std::get<0>(movable_simplex_types_).size() << std::endl;
+    std::cout << "(2,2) simplices: "
+              << std::get<1>(movable_simplex_types_).size() << std::endl;
+    std::cout << "(1,3) simplices: "
+              << std::get<2>(movable_simplex_types_).size() << std::endl;
+    std::cout << "Timelike edges: "
+              << movable_edge_types_.first.size() << std::endl;
+    std::cout << "Spacelike edges: "
+              << movable_edge_types_.second << std::endl;
+    std::cout << "Vertices: "
+              << number_of_vertices_ << std::endl;
+  //   universe_ptr = std::move(make_triangulation(simplices, timeslices));
+  //   simplex_types = classify_simplices(universe_ptr);
+  //   edge_types = classify_edges(universe_ptr);
+  //   number_of_vertices_before = universe_ptr->number_of_vertices();
+  //   N3_31_before = std::get<0>(simplex_types).size();
+  //   N3_22_before = std::get<1>(simplex_types).size();
+  //   N3_13_before = std::get<2>(simplex_types).size();
+  //   V2_before = edge_types.first.size();
+  //   std::cout << "Number of vertices before = " << number_of_vertices_before
+  //             << std::endl;
+  //   std::cout << "Number of (3,1) simplices before = " << N3_31_before
+  //             << std::endl;
+  //   std::cout << "Number of (2,2) simplices before = " << N3_22_before
+  //             << std::endl;
+  //   std::cout << "Number of (1,3) simplices before = " << N3_13_before
+  //             << std::endl;
+  //   std::cout << "Number of timelike edges before = " << V2_before
+  //             << std::endl;
   }
-  Delaunay universe;
-  std::unique_ptr<decltype(universe)>
-    universe_ptr = std::make_unique<decltype(universe)>(universe);
-  static constexpr auto simplices = static_cast<unsigned>(6400);
-  static constexpr auto timeslices = static_cast<unsigned>(16);
+
+  std::unique_ptr<Delaunay> universe_;
+  ///< Unique pointer to the Delaunay triangulation.
   std::tuple<std::vector<Cell_handle>,
              std::vector<Cell_handle>,
-             std::vector<Cell_handle>> simplex_types;
+             std::vector<Cell_handle>> movable_simplex_types_;
+  ///< Movable (3,1), (2,2), and (1,3) simplices.
+  std::pair<std::vector<Edge_tuple>, std::uintmax_t> movable_edge_types_;
+  ///< Movable timelike and spacelike edges.
+  move_tuple attempted_moves_;
+  ///< A count of all attempted moves.
+  std::uintmax_t number_of_vertices_;
+  ///< Vertices in Delaunay triangulation.
+  // Delaunay universe;
+  // std::unique_ptr<decltype(universe)>
+  //   universe_ptr = std::make_unique<decltype(universe)>(universe);
+  // static constexpr auto simplices = static_cast<unsigned>(6400);
+  // static constexpr auto timeslices = static_cast<unsigned>(16);
   // std::tuple<std::vector<Cell_handle>,
   //            std::vector<Cell_handle>,
-  //            std::vector<Cell_handle>> movable_simplex_types;
-  std::pair<std::vector<Edge_tuple>, unsigned> edge_types;
-  unsigned number_of_vertices_before{0};
-  unsigned N3_31_before{0};
-  unsigned N3_22_before{0};
-  unsigned N3_13_before{0};
-  unsigned V2_before{0};
-  move_tuple attempted_moves;
+  //            std::vector<Cell_handle>> simplex_types;
+  // // std::tuple<std::vector<Cell_handle>,
+  // //            std::vector<Cell_handle>,
+  // //            std::vector<Cell_handle>> movable_simplex_types;
+  // std::pair<std::vector<Edge_tuple>, unsigned> edge_types;
+  // unsigned number_of_vertices_before{0};
+  // unsigned N3_31_before{0};
+  // unsigned N3_22_before{0};
+  // unsigned N3_13_before{0};
+  // unsigned V2_before{0};
+  // move_tuple attempted_moves;
 };
 
-class Minimal26Test : public S3ErgodicMoves {
- protected:
-  virtual void SetUp() {
-    // Manually create causal_vertices
-    std::pair<std::vector<Point>, std::vector<unsigned>>
-      causal_vertices(V, timevalue);
-    // Manually insert
-    insert_into_triangulation(universe_ptr, causal_vertices);
-    simplex_types = classify_simplices(universe_ptr);
-    edge_types = classify_edges(universe_ptr);
-    number_of_vertices_before = universe_ptr->number_of_vertices();
-    N3_31_before = std::get<0>(simplex_types).size();
-    N3_22_before = std::get<1>(simplex_types).size();
-    N3_13_before = std::get<2>(simplex_types).size();
-    V2_before = edge_types.first.size();
-    std::cout << "Number of vertices before = " << number_of_vertices_before
-              << std::endl;
-    std::cout << "Number of (3,1) simplices before = " << N3_31_before
-              << std::endl;
-    std::cout << "Number of (2,2) simplices before = " << N3_22_before
-              << std::endl;
-    std::cout << "Number of (1,3) simplices before = " << N3_13_before
-              << std::endl;
-    std::cout << "Number of timelike edges before = " << V2_before
-              << std::endl;
-  }
-  std::vector<Delaunay::Point> V {
-    Delaunay::Point(0, 1, 0),
-    Delaunay::Point(0, 0, 1),
-    Delaunay::Point(1, 1, 1),
-    Delaunay::Point(-1, 1, 1),
-    Delaunay::Point(0, 0, 2)};
-  std::vector<unsigned> timevalue {1, 2, 2, 2, 3};
-};
+// class Minimal26Test : public S3ErgodicMoveTest {
+//  protected:
+//    Minimal26Test() : universe_(std::move(insert_into_triangulation(
+//                                universe_, causal_vertices))),
+//                      movable_simplex_types_(classify_simplices(universe_)),
+//                      movable_edge_types_(classify_edges(universe_)),
+//                      attempted_moves_(std::make_tuple(0, 0, 0, 0, 0)),
+//                      number_of_vertices_(universe_->number_of_vertices()) {}
+  // virtual void SetUp() {
+  //   // Manually create causal_vertices
+  //   std::pair<std::vector<Point>, std::vector<unsigned>>
+  //     causal_vertices(V, timevalue);
+  //   // Manually insert
+  //   insert_into_triangulation(universe_ptr, causal_vertices);
+  //   simplex_types = classify_simplices(universe_ptr);
+  //   edge_types = classify_edges(universe_ptr);
+  //   number_of_vertices_before = universe_ptr->number_of_vertices();
+  //   N3_31_before = std::get<0>(simplex_types).size();
+  //   N3_22_before = std::get<1>(simplex_types).size();
+  //   N3_13_before = std::get<2>(simplex_types).size();
+  //   V2_before = edge_types.first.size();
+  //   std::cout << "Number of vertices before = " << number_of_vertices_before
+  //             << std::endl;
+  //   std::cout << "Number of (3,1) simplices before = " << N3_31_before
+  //             << std::endl;
+  //   std::cout << "Number of (2,2) simplices before = " << N3_22_before
+  //             << std::endl;
+  //   std::cout << "Number of (1,3) simplices before = " << N3_13_before
+  //             << std::endl;
+  //   std::cout << "Number of timelike edges before = " << V2_before
+  //             << std::endl;
+  // }
+//   std::vector<Delaunay::Point> V {
+//     Delaunay::Point(0, 1, 0),
+//     Delaunay::Point(0, 0, 1),
+//     Delaunay::Point(1, 1, 1),
+//     Delaunay::Point(-1, 1, 1),
+//     Delaunay::Point(0, 0, 2)};
+//   std::vector<std::uintmax_t> timevalue {1, 2, 2, 2, 3};
+//   std::pair<std::vector<Point>, std::vector<std::uintmax_t>>
+//     causal_vertices{V, timevalue};
+// };
 
-class Minimal62Test : public Minimal26Test {
- protected:
-  virtual void SetUp() {
-    // Manually create causal_vertices
-    std::pair<std::vector<Point>, std::vector<unsigned>>
-      causal_vertices(V, timevalue);
-    // Manually insert
-    insert_into_triangulation(universe_ptr, causal_vertices);
-    // We have a (1,3) and (3,1) now use make_26_move() to create test case
-    universe_ptr = std::move(make_26_move(universe_ptr,
-                                          simplex_types,
-                                          attempted_moves));
-    // Now classify
-    simplex_types = classify_simplices(universe_ptr);
-    edge_types = classify_edges(universe_ptr);
-    number_of_vertices_before = universe_ptr->number_of_vertices();
-    N3_31_before = std::get<0>(simplex_types).size();
-    N3_22_before = std::get<1>(simplex_types).size();
-    N3_13_before = std::get<2>(simplex_types).size();
-    V2_before = edge_types.first.size();
-    std::cout << "Number of vertices before = " << number_of_vertices_before
-              << std::endl;
-    std::cout << "Number of (3,1) simplices before = " << N3_31_before
-              << std::endl;
-    std::cout << "Number of (2,2) simplices before = " << N3_22_before
-              << std::endl;
-    std::cout << "Number of (1,3) simplices before = " << N3_13_before
-              << std::endl;
-    std::cout << "Number of timelike edges before = " << V2_before
-              << std::endl;
-  }
-};
-
-
-TEST_F(S3ErgodicMoves, MakeA23Move) {
-  universe_ptr = std::move(make_23_move(universe_ptr,
-                                        simplex_types,
-                                        attempted_moves));
-  std::cout << "Attempted (2,3) moves = " << std::get<0>(attempted_moves)
-            << std::endl;
-
-  // Did we remove a (2,2) Cell_handle?
-  EXPECT_THAT(std::get<1>(simplex_types).size(), Le(N3_22_before-1))
-    << "make_23_move didn't remove a (2,2) simplex vector element.";
-
-  // Did we record an attempted move?
-  EXPECT_THAT(std::get<0>(attempted_moves) +
-              std::get<1>(simplex_types).size(), Eq(N3_22_before))
-    << "Attempted (2,3) moves not recorded correctly.";
-
-  EXPECT_THAT(std::get<0>(simplex_types).size(), Eq(N3_31_before))
-    << "make_23_move removed a (3,1) simplex vector element.";
-
-  EXPECT_THAT(std::get<2>(simplex_types).size(), Eq(N3_13_before))
-    << "make_23_move removed a (1,3) simplex vector element.";
-
-  // Now look at changes
-  simplex_types = classify_simplices(universe_ptr);
-  auto N3_31_after = std::get<0>(simplex_types).size();
-  auto N3_22_after = std::get<1>(simplex_types).size();
-  auto N3_13_after = std::get<2>(simplex_types).size();
-
-  // We expect the triangulation to be valid, but not necessarily Delaunay
-  EXPECT_TRUE(universe_ptr->tds().is_valid())
-    << "Triangulation is invalid.";
-
-  EXPECT_THAT(universe_ptr->dimension(), Eq(3))
-    << "Triangulation has wrong dimensionality.";
-
-  EXPECT_TRUE(fix_timeslices(universe_ptr))
-    << "Some simplices do not span exactly 1 timeslice.";
-
-  EXPECT_THAT(universe_ptr->number_of_vertices(), Eq(number_of_vertices_before))
-    << "The number of vertices changed.";
-
-  EXPECT_THAT(N3_31_after, Eq(N3_31_before))
-    << "(3,1) simplices changed.";
-
-  EXPECT_THAT(N3_22_after, Eq(N3_22_before+1))
-    << "(2,2) simplices did not increase by 1.";
-
-  EXPECT_THAT(N3_13_after, Eq(N3_13_before))
-    << "(1,3) simplices changed.";
-}
-
-TEST_F(S3ErgodicMoves, MakeA32Move) {
-  universe_ptr = std::move(make_32_move(universe_ptr,
-                                        edge_types,
-                                        attempted_moves));
-  // auto attempted_32_moves = std::get<1>(attempted_moves);
-  std::cout << "Attempted (3,2) moves = " << std::get<1>(attempted_moves)
-                                          << std::endl;
-
-  // Did we remove a timelike edge?
-  EXPECT_THAT(edge_types.first.size(), Le(V2_before-1))
-    << "make_32_move didn't remove a timelike edge vector element.";
-
-  // Did we record attempted (3,2) moves?
-  EXPECT_THAT(std::get<1>(attempted_moves) + edge_types.first.size(),
-              Eq(V2_before))
-    << "Attempted (3,2) moves not recorded correctly.";
-
-  // Now look at changes
-  simplex_types = classify_simplices(universe_ptr);
-  auto N3_31_after = std::get<0>(simplex_types).size();
-  auto N3_22_after = std::get<1>(simplex_types).size();
-  auto N3_13_after = std::get<2>(simplex_types).size();
-  edge_types = classify_edges(universe_ptr);
-  auto V2_after = edge_types.first.size();
-
-  // We expect the triangulation to be valid, but not necessarily Delaunay
-  EXPECT_TRUE(universe_ptr->tds().is_valid())
-    << "Triangulation is invalid.";
-
-  EXPECT_THAT(universe_ptr->dimension(), Eq(3))
-    << "Triangulation has wrong dimensionality.";
-
-  EXPECT_TRUE(fix_timeslices(universe_ptr))
-    << "Some simplices do not span exactly 1 timeslice.";
-
-  EXPECT_THAT(universe_ptr->number_of_vertices(), Eq(number_of_vertices_before))
-    << "The number of vertices changed.";
-
-  EXPECT_THAT(N3_31_after, Eq(N3_31_before))
-    << "(3,1) simplices changed.";
-
-  EXPECT_THAT(N3_22_after, Eq(N3_22_before-1))
-    << "(2,2) simplices did not decrease by 1.";
-
-  EXPECT_THAT(N3_13_after, Eq(N3_13_before))
-    << "(1,3) simplices changed.";
-
-  EXPECT_THAT(V2_after, Eq(V2_before-1))
-    << "The edge that was flipped wasn't removed.";
-}
-
-TEST_F(Minimal26Test, MakeA26Move) {
-  universe_ptr = std::move(make_26_move(universe_ptr,
-                                        simplex_types,
-                                        attempted_moves));
-
-  // Now look at changes
-  simplex_types = classify_simplices(universe_ptr);
-  auto N3_31_after = std::get<0>(simplex_types).size();
-  auto N3_22_after = std::get<1>(simplex_types).size();
-  auto N3_13_after = std::get<2>(simplex_types).size();
-
-  EXPECT_TRUE(universe_ptr->tds().is_valid(true))
-    << "Triangulation is invalid.";
-
-  EXPECT_THAT(universe_ptr->dimension(), Eq(3))
-    << "Triangulation has wrong dimensionality.";
-
-  EXPECT_TRUE(fix_timeslices(universe_ptr))
-    << "Some simplices do not span exactly 1 timeslice.";
-
-  EXPECT_THAT(universe_ptr->number_of_vertices(),
-              Eq(number_of_vertices_before+1))
-    << "A vertex was not added to the triangulation.";
-
-  EXPECT_THAT(N3_31_after, Eq(N3_31_before+2))
-    << "(3,1) simplices did not increase by 2.";
-
-  EXPECT_THAT(N3_22_after, Eq(N3_22_before))
-    << "(2,2) simplices changed.";
-
-  EXPECT_THAT(N3_13_after, Eq(N3_13_before+2))
-    << "(1,3) simplices did not increase by 2.";
-}
-
-TEST_F(S3ErgodicMoves, MakeA26Move) {
-  universe_ptr = std::move(make_26_move(universe_ptr,
-                                        simplex_types,
-                                        attempted_moves));
-
-  // Now look at changes
-  simplex_types = classify_simplices(universe_ptr);
-  auto N3_31_after = std::get<0>(simplex_types).size();
-  auto N3_22_after = std::get<1>(simplex_types).size();
-  auto N3_13_after = std::get<2>(simplex_types).size();
-
-  EXPECT_TRUE(universe_ptr->tds().is_valid(true))
-    << "Triangulation is invalid.";
-
-  EXPECT_THAT(universe_ptr->dimension(), Eq(3))
-    << "Triangulation has wrong dimensionality.";
-
-  EXPECT_TRUE(fix_timeslices(universe_ptr))
-    << "Some simplices do not span exactly 1 timeslice.";
-
-  EXPECT_THAT(universe_ptr->number_of_vertices(),
-              Eq(number_of_vertices_before+1))
-    << "A vertex was not added to the triangulation.";
-
-  EXPECT_THAT(N3_31_after, Eq(N3_31_before+2))
-    << "(3,1) simplices did not increase by 2.";
-
-  EXPECT_THAT(N3_22_after, Eq(N3_22_before))
-    << "(2,2) simplices changed.";
-
-  EXPECT_THAT(N3_13_after, Eq(N3_13_before+2))
-    << "(1,3) simplices did not increase by 2.";
-}
-
-TEST_F(S3ErgodicMoves, DISABLED_MakeA62Move) {
-  universe_ptr = std::move(make_62_move(universe_ptr,
-                                        edge_types,
-                                        attempted_moves));
-
-  // Now look at changes
-  simplex_types = classify_simplices(universe_ptr);
-  auto N3_31_after = std::get<0>(simplex_types).size();
-  auto N3_22_after = std::get<1>(simplex_types).size();
-  auto N3_13_after = std::get<2>(simplex_types).size();
-
-  EXPECT_TRUE(universe_ptr->tds().is_valid(true))
-    << "Triangulation is invalid.";
-
-  EXPECT_THAT(universe_ptr->dimension(), Eq(3))
-    << "Triangulation has wrong dimensionality.";
-
-  EXPECT_TRUE(fix_timeslices(universe_ptr))
-    << "Some simplices do not span exactly 1 timeslice.";
-
-  EXPECT_THAT(universe_ptr->number_of_vertices(),
-              Eq(number_of_vertices_before-1))
-    << "A vertex was not subtracted from the triangulation.";
-
-  EXPECT_THAT(N3_31_after, Eq(N3_31_before-2))
-    << "(3,1) simplices did not decrease by 2.";
-
-  EXPECT_THAT(N3_22_after, Eq(N3_22_before))
-    << "(2,2) simplices changed.";
-
-  EXPECT_THAT(N3_13_after, Eq(N3_13_before-2))
-    << "(1,3) simplices did not decrease by 2.";
-}
+// class Minimal62Test : public Minimal26Test {
+//  protected:
+//   virtual void SetUp() {
+//     // Manually create causal_vertices
+//     std::pair<std::vector<Point>, std::vector<unsigned>>
+//       causal_vertices(V, timevalue);
+//     // Manually insert
+//     insert_into_triangulation(universe_ptr, causal_vertices);
+//     // We have a (1,3) and (3,1) now use make_26_move() to create test case
+//     universe_ptr = std::move(make_26_move(universe_ptr,
+//                                           simplex_types,
+//                                           attempted_moves));
+//     // Now classify
+//     simplex_types = classify_simplices(universe_ptr);
+//     edge_types = classify_edges(universe_ptr);
+//     number_of_vertices_before = universe_ptr->number_of_vertices();
+//     N3_31_before = std::get<0>(simplex_types).size();
+//     N3_22_before = std::get<1>(simplex_types).size();
+//     N3_13_before = std::get<2>(simplex_types).size();
+//     V2_before = edge_types.first.size();
+//     std::cout << "Number of vertices before = " << number_of_vertices_before
+//               << std::endl;
+//     std::cout << "Number of (3,1) simplices before = " << N3_31_before
+//               << std::endl;
+//     std::cout << "Number of (2,2) simplices before = " << N3_22_before
+//               << std::endl;
+//     std::cout << "Number of (1,3) simplices before = " << N3_13_before
+//               << std::endl;
+//     std::cout << "Number of timelike edges before = " << V2_before
+//               << std::endl;
+//   }
+// };
+//
+//
+// TEST_F(S3ErgodicMoves, MakeA23Move) {
+//   universe_ptr = std::move(make_23_move(universe_ptr,
+//                                         simplex_types,
+//                                         attempted_moves));
+//   std::cout << "Attempted (2,3) moves = " << std::get<0>(attempted_moves)
+//             << std::endl;
+//
+//   // Did we remove a (2,2) Cell_handle?
+//   EXPECT_THAT(std::get<1>(simplex_types).size(), Le(N3_22_before-1))
+//     << "make_23_move didn't remove a (2,2) simplex vector element.";
+//
+//   // Did we record an attempted move?
+//   EXPECT_THAT(std::get<0>(attempted_moves) +
+//               std::get<1>(simplex_types).size(), Eq(N3_22_before))
+//     << "Attempted (2,3) moves not recorded correctly.";
+//
+//   EXPECT_THAT(std::get<0>(simplex_types).size(), Eq(N3_31_before))
+//     << "make_23_move removed a (3,1) simplex vector element.";
+//
+//   EXPECT_THAT(std::get<2>(simplex_types).size(), Eq(N3_13_before))
+//     << "make_23_move removed a (1,3) simplex vector element.";
+//
+//   // Now look at changes
+//   simplex_types = classify_simplices(universe_ptr);
+//   auto N3_31_after = std::get<0>(simplex_types).size();
+//   auto N3_22_after = std::get<1>(simplex_types).size();
+//   auto N3_13_after = std::get<2>(simplex_types).size();
+//
+//   // We expect the triangulation to be valid, but not necessarily Delaunay
+//   EXPECT_TRUE(universe_ptr->tds().is_valid())
+//     << "Triangulation is invalid.";
+//
+//   EXPECT_THAT(universe_ptr->dimension(), Eq(3))
+//     << "Triangulation has wrong dimensionality.";
+//
+//   EXPECT_TRUE(fix_timeslices(universe_ptr))
+//     << "Some simplices do not span exactly 1 timeslice.";
+//
+//   EXPECT_THAT(universe_ptr->number_of_vertices(), Eq(number_of_vertices_before))
+//     << "The number of vertices changed.";
+//
+//   EXPECT_THAT(N3_31_after, Eq(N3_31_before))
+//     << "(3,1) simplices changed.";
+//
+//   EXPECT_THAT(N3_22_after, Eq(N3_22_before+1))
+//     << "(2,2) simplices did not increase by 1.";
+//
+//   EXPECT_THAT(N3_13_after, Eq(N3_13_before))
+//     << "(1,3) simplices changed.";
+// }
+//
+// TEST_F(S3ErgodicMoves, MakeA32Move) {
+//   universe_ptr = std::move(make_32_move(universe_ptr,
+//                                         edge_types,
+//                                         attempted_moves));
+//   // auto attempted_32_moves = std::get<1>(attempted_moves);
+//   std::cout << "Attempted (3,2) moves = " << std::get<1>(attempted_moves)
+//                                           << std::endl;
+//
+//   // Did we remove a timelike edge?
+//   EXPECT_THAT(edge_types.first.size(), Le(V2_before-1))
+//     << "make_32_move didn't remove a timelike edge vector element.";
+//
+//   // Did we record attempted (3,2) moves?
+//   EXPECT_THAT(std::get<1>(attempted_moves) + edge_types.first.size(),
+//               Eq(V2_before))
+//     << "Attempted (3,2) moves not recorded correctly.";
+//
+//   // Now look at changes
+//   simplex_types = classify_simplices(universe_ptr);
+//   auto N3_31_after = std::get<0>(simplex_types).size();
+//   auto N3_22_after = std::get<1>(simplex_types).size();
+//   auto N3_13_after = std::get<2>(simplex_types).size();
+//   edge_types = classify_edges(universe_ptr);
+//   auto V2_after = edge_types.first.size();
+//
+//   // We expect the triangulation to be valid, but not necessarily Delaunay
+//   EXPECT_TRUE(universe_ptr->tds().is_valid())
+//     << "Triangulation is invalid.";
+//
+//   EXPECT_THAT(universe_ptr->dimension(), Eq(3))
+//     << "Triangulation has wrong dimensionality.";
+//
+//   EXPECT_TRUE(fix_timeslices(universe_ptr))
+//     << "Some simplices do not span exactly 1 timeslice.";
+//
+//   EXPECT_THAT(universe_ptr->number_of_vertices(), Eq(number_of_vertices_before))
+//     << "The number of vertices changed.";
+//
+//   EXPECT_THAT(N3_31_after, Eq(N3_31_before))
+//     << "(3,1) simplices changed.";
+//
+//   EXPECT_THAT(N3_22_after, Eq(N3_22_before-1))
+//     << "(2,2) simplices did not decrease by 1.";
+//
+//   EXPECT_THAT(N3_13_after, Eq(N3_13_before))
+//     << "(1,3) simplices changed.";
+//
+//   EXPECT_THAT(V2_after, Eq(V2_before-1))
+//     << "The edge that was flipped wasn't removed.";
+// }
+//
+// TEST_F(Minimal26Test, MakeA26Move) {
+//   universe_ptr = std::move(make_26_move(universe_ptr,
+//                                         simplex_types,
+//                                         attempted_moves));
+//
+//   // Now look at changes
+//   simplex_types = classify_simplices(universe_ptr);
+//   auto N3_31_after = std::get<0>(simplex_types).size();
+//   auto N3_22_after = std::get<1>(simplex_types).size();
+//   auto N3_13_after = std::get<2>(simplex_types).size();
+//
+//   EXPECT_TRUE(universe_ptr->tds().is_valid(true))
+//     << "Triangulation is invalid.";
+//
+//   EXPECT_THAT(universe_ptr->dimension(), Eq(3))
+//     << "Triangulation has wrong dimensionality.";
+//
+//   EXPECT_TRUE(fix_timeslices(universe_ptr))
+//     << "Some simplices do not span exactly 1 timeslice.";
+//
+//   EXPECT_THAT(universe_ptr->number_of_vertices(),
+//               Eq(number_of_vertices_before+1))
+//     << "A vertex was not added to the triangulation.";
+//
+//   EXPECT_THAT(N3_31_after, Eq(N3_31_before+2))
+//     << "(3,1) simplices did not increase by 2.";
+//
+//   EXPECT_THAT(N3_22_after, Eq(N3_22_before))
+//     << "(2,2) simplices changed.";
+//
+//   EXPECT_THAT(N3_13_after, Eq(N3_13_before+2))
+//     << "(1,3) simplices did not increase by 2.";
+// }
+//
+// TEST_F(S3ErgodicMoves, MakeA26Move) {
+//   universe_ptr = std::move(make_26_move(universe_ptr,
+//                                         simplex_types,
+//                                         attempted_moves));
+//
+//   // Now look at changes
+//   simplex_types = classify_simplices(universe_ptr);
+//   auto N3_31_after = std::get<0>(simplex_types).size();
+//   auto N3_22_after = std::get<1>(simplex_types).size();
+//   auto N3_13_after = std::get<2>(simplex_types).size();
+//
+//   EXPECT_TRUE(universe_ptr->tds().is_valid(true))
+//     << "Triangulation is invalid.";
+//
+//   EXPECT_THAT(universe_ptr->dimension(), Eq(3))
+//     << "Triangulation has wrong dimensionality.";
+//
+//   EXPECT_TRUE(fix_timeslices(universe_ptr))
+//     << "Some simplices do not span exactly 1 timeslice.";
+//
+//   EXPECT_THAT(universe_ptr->number_of_vertices(),
+//               Eq(number_of_vertices_before+1))
+//     << "A vertex was not added to the triangulation.";
+//
+//   EXPECT_THAT(N3_31_after, Eq(N3_31_before+2))
+//     << "(3,1) simplices did not increase by 2.";
+//
+//   EXPECT_THAT(N3_22_after, Eq(N3_22_before))
+//     << "(2,2) simplices changed.";
+//
+//   EXPECT_THAT(N3_13_after, Eq(N3_13_before+2))
+//     << "(1,3) simplices did not increase by 2.";
+// }
+//
+// TEST_F(S3ErgodicMoves, DISABLED_MakeA62Move) {
+//   universe_ptr = std::move(make_62_move(universe_ptr,
+//                                         edge_types,
+//                                         attempted_moves));
+//
+//   // Now look at changes
+//   simplex_types = classify_simplices(universe_ptr);
+//   auto N3_31_after = std::get<0>(simplex_types).size();
+//   auto N3_22_after = std::get<1>(simplex_types).size();
+//   auto N3_13_after = std::get<2>(simplex_types).size();
+//
+//   EXPECT_TRUE(universe_ptr->tds().is_valid(true))
+//     << "Triangulation is invalid.";
+//
+//   EXPECT_THAT(universe_ptr->dimension(), Eq(3))
+//     << "Triangulation has wrong dimensionality.";
+//
+//   EXPECT_TRUE(fix_timeslices(universe_ptr))
+//     << "Some simplices do not span exactly 1 timeslice.";
+//
+//   EXPECT_THAT(universe_ptr->number_of_vertices(),
+//               Eq(number_of_vertices_before-1))
+//     << "A vertex was not subtracted from the triangulation.";
+//
+//   EXPECT_THAT(N3_31_after, Eq(N3_31_before-2))
+//     << "(3,1) simplices did not decrease by 2.";
+//
+//   EXPECT_THAT(N3_22_after, Eq(N3_22_before))
+//     << "(2,2) simplices changed.";
+//
+//   EXPECT_THAT(N3_13_after, Eq(N3_13_before-2))
+//     << "(1,3) simplices did not decrease by 2.";
+// }

--- a/unittests/TetrahedronTest.cpp
+++ b/unittests/TetrahedronTest.cpp
@@ -20,7 +20,7 @@
 using namespace testing;  // NOLINT
 
 class TetrahedronTest : public Test {
- public:
+ protected:
   TetrahedronTest() {
     // We wouldn't normally directly insert into the Delaunay triangulation
     // This is to insert without timevalues to directly create a tetrahedron
@@ -39,7 +39,7 @@ class TetrahedronTest : public Test {
 };
 
 class FoliatedTetrahedronTest : public TetrahedronTest {
- public:
+ protected:
   FoliatedTetrahedronTest() : causal_vertices(std::make_pair(V, timevalue)) {
     // Manually insert
     insert_into_triangulation(universe_, causal_vertices);

--- a/unittests/TetrahedronTest.cpp
+++ b/unittests/TetrahedronTest.cpp
@@ -1,6 +1,6 @@
 /// Causal Dynamical Triangulations in C++ using CGAL
 ///
-/// Copyright (c) 2014, 2015 Adam Getchell
+/// Copyright (c) 2014-2016 Adam Getchell
 ///
 /// Tests that 3-dimensional triangulated & foliated tetrahedrons are
 /// constructed correctly.
@@ -15,21 +15,21 @@
 #include <utility>
 
 #include "gmock/gmock.h"
-#include "S3Triangulation.h"
+#include "src/S3Triangulation.h"
 
 using namespace testing;  // NOLINT
 
-class Tetrahedron : public Test {
- protected:
-  virtual void SetUp() {
+class TetrahedronTest : public Test {
+ public:
+  TetrahedronTest() {
     // We wouldn't normally directly insert into the Delaunay triangulation
     // This is to insert without timevalues to directly create a tetrahedron
-    universe_ptr->insert(V.begin(), V.end());
+    universe_->insert(V.begin(), V.end());
   }
 
   Delaunay universe;
   std::unique_ptr<Delaunay>
-    universe_ptr = std::make_unique<decltype(universe)>(universe);
+    universe_ = std::make_unique<decltype(universe)>(universe);
   std::vector<Delaunay::Point> V {
     Delaunay::Point(0, 0, 0),
     Delaunay::Point(0, 1, 0),
@@ -38,67 +38,66 @@ class Tetrahedron : public Test {
   };
 };
 
-class FoliatedTetrahedron : public Tetrahedron {
- protected:
-    virtual void SetUp() {
-     // Manually create causal_vertices
-      std::pair<std::vector<Point>, std::vector<unsigned>>
-       causal_vertices(V, timevalue);
-     // Manually insert
-     insert_into_triangulation(universe_ptr, causal_vertices);
-    }
-    std::vector<unsigned> timevalue {1, 1, 1, 2};
+class FoliatedTetrahedronTest : public TetrahedronTest {
+ public:
+  FoliatedTetrahedronTest() : causal_vertices(std::make_pair(V, timevalue)) {
+    // Manually insert
+    insert_into_triangulation(universe_, causal_vertices);
+  }
+
+  std::vector<std::uintmax_t> timevalue {1, 1, 1, 2};
+  std::pair<std::vector<Point>, std::vector<std::uintmax_t>> causal_vertices;
 };
 
-TEST_F(Tetrahedron, Create) {
-  EXPECT_THAT(universe_ptr->dimension(), Eq(3))
+TEST_F(TetrahedronTest, Create) {
+  EXPECT_THAT(universe_->dimension(), Eq(3))
     << "Triangulation has wrong dimensionality.";
 
-  EXPECT_THAT(universe_ptr->number_of_vertices(), Eq(4))
+  EXPECT_THAT(universe_->number_of_vertices(), Eq(4))
     << "Triangulation has wrong number of vertices.";
 
-  EXPECT_THAT(universe_ptr->number_of_finite_edges(), Eq(6))
+  EXPECT_THAT(universe_->number_of_finite_edges(), Eq(6))
     << "Triangulation has wrong number of edges.";
 
-  EXPECT_THAT(universe_ptr->number_of_finite_facets(), Eq(4))
+  EXPECT_THAT(universe_->number_of_finite_facets(), Eq(4))
     << "Triangulation has wrong number of faces.";
 
-  EXPECT_THAT(universe_ptr->number_of_finite_cells(), Eq(1))
+  EXPECT_THAT(universe_->number_of_finite_cells(), Eq(1))
     << "Triangulation has wrong number of cells.";
 
-  EXPECT_TRUE(universe_ptr->is_valid())
+  EXPECT_TRUE(universe_->is_valid())
     << "Triangulation is not Delaunay.";
 
-  EXPECT_TRUE(universe_ptr->tds().is_valid())
+  EXPECT_TRUE(universe_->tds().is_valid())
     << "Triangulation is invalid.";
 }
 
-TEST_F(FoliatedTetrahedron, Create) {
-  EXPECT_THAT(universe_ptr->dimension(), Eq(3))
+TEST_F(FoliatedTetrahedronTest, Create) {
+  EXPECT_THAT(universe_->dimension(), Eq(3))
     << "Triangulation has wrong dimensionality.";
 
-  EXPECT_THAT(universe_ptr->number_of_vertices(), Eq(4))
+  EXPECT_THAT(universe_->number_of_vertices(), Eq(4))
     << "Triangulation has wrong number of vertices.";
 
-  EXPECT_THAT(universe_ptr->number_of_finite_cells(), Eq(1))
+  EXPECT_THAT(universe_->number_of_finite_cells(), Eq(1))
     << "Triangulation has wrong number of cells.";
 
-  EXPECT_TRUE(fix_timeslices(universe_ptr))
+  EXPECT_TRUE(fix_timeslices(universe_))
     << "Some simplices do not span exactly 1 timeslice.";
 
-  EXPECT_TRUE(universe_ptr->is_valid())
+  EXPECT_TRUE(universe_->is_valid())
     << "Triangulation is not Delaunay.";
 
-  EXPECT_TRUE(universe_ptr->tds().is_valid())
+  EXPECT_TRUE(universe_->tds().is_valid())
     << "Triangulation is invalid.";
 }
 
-TEST_F(FoliatedTetrahedron, InsertSimplexType) {
-  auto simplex_types = classify_simplices(universe_ptr);
+TEST_F(FoliatedTetrahedronTest, InsertSimplexType) {
+  auto simplex_types = classify_simplices(universe_);
 
   Delaunay::Finite_cells_iterator cit;
-  for (cit = universe_ptr->finite_cells_begin();
-       cit != universe_ptr->finite_cells_end(); ++cit) {
+  for (cit = universe_->finite_cells_begin();
+       cit != universe_->finite_cells_end(); ++cit) {
     EXPECT_THAT(cit->info(), Eq(31));
     std::cout << "Simplex type is " << cit->info() << std::endl;
   }
@@ -113,21 +112,21 @@ TEST_F(FoliatedTetrahedron, InsertSimplexType) {
     << "(1,3) vector in tuple is nonzero.";
 }
 
-TEST_F(FoliatedTetrahedron, GetTimelikeEdges) {
-  auto edge_types = classify_edges(universe_ptr);
+TEST_F(FoliatedTetrahedronTest, GetTimelikeEdges) {
+  auto edge_types = classify_edges(universe_);
   auto timelike_edges = edge_types.first;
   auto spacelike_edges = edge_types.second;
 
   std::cout << "There are " << timelike_edges.size() << " timelike edges and "
             << spacelike_edges << " spacelike edges." << std::endl;
 
-  EXPECT_THAT(universe_ptr->dimension(), Eq(3))
+  EXPECT_THAT(universe_->dimension(), Eq(3))
     << "Triangulation has wrong dimensionality.";
 
-  EXPECT_THAT(universe_ptr->number_of_vertices(), Eq(4))
+  EXPECT_THAT(universe_->number_of_vertices(), Eq(4))
     << "Triangulation has wrong number of vertices.";
 
-  EXPECT_THAT(universe_ptr->number_of_finite_cells(), Eq(1))
+  EXPECT_THAT(universe_->number_of_finite_cells(), Eq(1))
     << "Triangulation has wrong number of cells.";
 
   EXPECT_THAT(timelike_edges.size(), Eq(3))
@@ -136,12 +135,12 @@ TEST_F(FoliatedTetrahedron, GetTimelikeEdges) {
   EXPECT_THAT(spacelike_edges, Eq(3))
     << "(3,1) tetrahedron doesn't have 3 spacelike edges.";
 
-  EXPECT_TRUE(fix_timeslices(universe_ptr))
+  EXPECT_TRUE(fix_timeslices(universe_))
     << "Some simplices do not span exactly 1 timeslice.";
 
-  EXPECT_TRUE(universe_ptr->is_valid())
+  EXPECT_TRUE(universe_->is_valid())
     << "Triangulation is not Delaunay.";
 
-  EXPECT_TRUE(universe_ptr->tds().is_valid())
+  EXPECT_TRUE(universe_->tds().is_valid())
     << "Triangulation is invalid.";
 }


### PR DESCRIPTION
MakeA26Move did not track whether moves had been attempted. Adding
these checks, which are in the other tests, exposed a subtle bug where
make_26_move() did not delete the attempted (1,3) Cell_handle s from
the list of possible (2,6) move sites.