### PR TITLE
Completed (6, 2) Moves test

### DIFF
--- a/src/S3ErgodicMoves.h
+++ b/src/S3ErgodicMoves.h
@@ -430,10 +430,11 @@ auto try_62_move(T&& universe, Vertex_handle candidate) {
 /// @returns universe The SimplicialManifold after the move has been made
 template <typename T1, typename T2>
 auto make_62_move(T1&& universe,
-                  T2&& attempted_moves)
+                  T2&& attempted_moves, bool& successful_move)
                   -> decltype(universe) {
     std::vector<Vertex_handle> tds_vertices = universe.geometry.vertices;
     auto not_moved = true;
+    successful_move = false;
     uintmax_t tds_vertices_size = universe.geometry.vertices.size();
     while ((not_moved) && (tds_vertices_size > 0)) {
         // do something
@@ -446,6 +447,7 @@ auto make_62_move(T1&& universe,
         if (try_62_move(universe, to_be_moved)) {
             universe.triangulation->remove(to_be_moved);
             not_moved = false;
+            successful_move = true;
         }
         tds_vertices.erase(tds_vertices.begin() + choice); //O(|V|) bottleneck
         tds_vertices_size--;
@@ -457,7 +459,6 @@ auto make_62_move(T1&& universe,
         std::cout << "No (6, 2) move is possible." << std::endl;
     }
     #endif
-
     return std::move(universe);
 }  // make_62_move()
 

--- a/src/S3ErgodicMoves.h
+++ b/src/S3ErgodicMoves.h
@@ -393,7 +393,7 @@ auto try_62_move(T1&& universe_ptr, Vertex_handle candidate){
     auto adjacent_cell = std::make_tuple(0, 0, 0); //holds how many (3, 1), (2, 2), and (1, 3) adjacent cells exist
     (universe_ptr.triangulation)->incident_cells(candidate, back_inserter(candidate_cells));
     for (auto cit: candidate_cells){
-      CGAL_triangulation_precondition(is_cell(cit));
+      CGAL_triangulation_precondition(universe_ptr.triangulation->is_cell(cit));
       if (cit->info() == 31){
         ++std::get<0>(adjacent_cell);
       }
@@ -436,10 +436,10 @@ auto make_62_move(T1&& universe_ptr, T2&& attempted_moves) -> decltype(universe_
     auto choice = generate_random_unsigned(0, tds_vertices_size - 1);
     Vertex_handle to_be_moved = tds_vertices.at(choice);
     // Ensure pre-conditions are satisfied
-    CGAL_triangulation_precondition(((universe_ptr.triangulation)->dimension() == 3));
-    CGAL_triangulation_expensive_precondition(is_vertex(to_be_moved));
+    CGAL_triangulation_precondition((universe_ptr.triangulation->dimension() == 3));
+    CGAL_triangulation_expensive_precondition(universe_ptr.triangulation->is_vertex(to_be_moved));
     if (try_62_move(universe_ptr, to_be_moved)){
-      (universe_ptr.triangulation)->remove(to_be_moved);
+      universe_ptr.triangulation->remove(to_be_moved);
       not_moved = false;
     }
 

--- a/unittests/S3ErgodicMovesTest.cpp
+++ b/unittests/S3ErgodicMovesTest.cpp
@@ -20,212 +20,240 @@ using namespace testing;  // NOLINT
 
 class S3ErgodicMoveTest : public Test {
  public:
-    S3ErgodicMoveTest() : universe_{std::move(make_triangulation(6400, 17))},
-                          attempted_moves_{std::make_tuple(0, 0, 0, 0, 0)},
-                          N3_31_before{universe_.geometry.three_one.size()},
-                          N3_22_before{universe_.geometry.two_two.size()},
-                          N3_13_before{universe_.geometry.one_three.size()},
-                          timelike_edges_before{
-                                  universe_.geometry.timelike_edges
-                                           .size()},
-                          spacelike_edges_before{universe_.geometry
-                                                          .spacelike_edges},
-                          vertices_before{
-                                  universe_.geometry.vertices.size()} { }
+	S3ErgodicMoveTest() : universe_{std::move(make_triangulation(6400, 17))},
+						  attempted_moves_{std::make_tuple(0, 0, 0, 0, 0)},
+						  N3_31_before{universe_.geometry.three_one.size()},
+						  N3_22_before{universe_.geometry.two_two.size()},
+						  N3_13_before{universe_.geometry.one_three.size()},
+						  timelike_edges_before{
+								  universe_.geometry.timelike_edges
+										   .size()},
+						  spacelike_edges_before{universe_.geometry
+														  .spacelike_edges},
+						  vertices_before{
+								  universe_.geometry.vertices.size()} { }
 
-    virtual void SetUp() {
-        // Print ctor-initialized values
-        std::cout << "Initial Triangulation ..." << '\n';
-        std::cout << "(3,1) simplices: "
-        << N3_31_before << '\n';
-        std::cout << "(2,2) simplices: "
-        << N3_22_before << '\n';
-        std::cout << "(1,3) simplices: "
-        << N3_13_before << '\n';
-        std::cout << "Timelike edges: "
-        << timelike_edges_before << '\n';
-        std::cout << "Spacelike edges: "
-        << spacelike_edges_before << '\n';
-        std::cout << "Vertices: "
-        << vertices_before << '\n';
-    }
+	virtual void SetUp() {
+		// Print ctor-initialized values
+		std::cout << "Initial Triangulation ..." << '\n';
+		std::cout << "(3,1) simplices: "
+		<< N3_31_before << '\n';
+		std::cout << "(2,2) simplices: "
+		<< N3_22_before << '\n';
+		std::cout << "(1,3) simplices: "
+		<< N3_13_before << '\n';
+		std::cout << "Timelike edges: "
+		<< timelike_edges_before << '\n';
+		std::cout << "Spacelike edges: "
+		<< spacelike_edges_before << '\n';
+		std::cout << "Vertices: "
+		<< vertices_before << '\n';
+	}
 
-    /// Simplicial manifold containing pointer to triangulation
-    /// and geometric information.
-    SimplicialManifold universe_;
+	/// Simplicial manifold containing pointer to triangulation
+	/// and geometric information.
+	SimplicialManifold universe_;
 
-    /// A count of all attempted moves.
-    Move_tuple attempted_moves_;
+	/// A count of all attempted moves.
+	Move_tuple attempted_moves_;
 
-    /// Initial number of (3,1) simplices
-    std::uintmax_t N3_31_before;
+	/// Initial number of (3,1) simplices
+	std::uintmax_t N3_31_before;
 
-    /// Initial number of (2,2) simplices
-    std::uintmax_t N3_22_before;
+	/// Initial number of (2,2) simplices
+	std::uintmax_t N3_22_before;
 
-    /// Initial number of (1,3) simplices
-    std::uintmax_t N3_13_before;
+	/// Initial number of (1,3) simplices
+	std::uintmax_t N3_13_before;
 
-    /// Initial number of timelike edges
-    std::uintmax_t timelike_edges_before;
+	/// Initial number of timelike edges
+	std::uintmax_t timelike_edges_before;
 
-    /// Initial number of spacelike edges
-    std::uintmax_t spacelike_edges_before;
+	/// Initial number of spacelike edges
+	std::uintmax_t spacelike_edges_before;
 
-    /// Initial number of vertices
-    std::uintmax_t vertices_before;
+	/// Initial number of vertices
+	std::uintmax_t vertices_before;
 };
 
 TEST_F(S3ErgodicMoveTest, MakeA23Move) {
-    universe_ = make_23_move(std::move(universe_),
-                                       attempted_moves_);
-    std::cout << "Attempted (2,3) moves = " << std::get<0>(attempted_moves_)
-        << std::endl;
+	universe_ = make_23_move(std::move(universe_),
+									   attempted_moves_);
+	std::cout << "Attempted (2,3) moves = " << std::get<0>(attempted_moves_)
+		<< std::endl;
 
-    EXPECT_THAT(universe_.geometry.three_one.size(), Eq(N3_31_before))
-        << "(3,1) simplex removed from movable_simplex_types_.";
+	EXPECT_THAT(universe_.geometry.three_one.size(), Eq(N3_31_before))
+		<< "(3,1) simplex removed from movable_simplex_types_.";
 
-    EXPECT_THAT(universe_.geometry.one_three.size(), Eq(N3_13_before))
-        << "(1,3) simplex removed from movable_simplex_types_.";
+	EXPECT_THAT(universe_.geometry.one_three.size(), Eq(N3_13_before))
+		<< "(1,3) simplex removed from movable_simplex_types_.";
 
-    // We expect the triangulation to be valid, but not necessarily Delaunay
-    EXPECT_TRUE(universe_.triangulation->tds().is_valid())
-        << "Triangulation is invalid.";
+	// We expect the triangulation to be valid, but not necessarily Delaunay
+	EXPECT_TRUE(universe_.triangulation->tds().is_valid())
+		<< "Triangulation is invalid.";
 
-    EXPECT_THAT(universe_.triangulation->dimension(), Eq(3))
-        << "Triangulation has wrong dimensionality.";
+	EXPECT_THAT(universe_.triangulation->dimension(), Eq(3))
+		<< "Triangulation has wrong dimensionality.";
 
-    EXPECT_TRUE(fix_timeslices(universe_.triangulation))
-        << "Some simplices do not span exactly 1 timeslice.";
+	EXPECT_TRUE(fix_timeslices(universe_.triangulation))
+		<< "Some simplices do not span exactly 1 timeslice.";
 
-    EXPECT_THAT(universe_.geometry.three_one.size(), Eq(N3_31_before))
-        << "(3,1) simplices changed.";
+	EXPECT_THAT(universe_.geometry.three_one.size(), Eq(N3_31_before))
+		<< "(3,1) simplices changed.";
 
-    EXPECT_THAT(universe_.geometry.two_two.size(), Eq(N3_22_before+1))
-        << "(2,2) simplices did not increase by 1.";
+	EXPECT_THAT(universe_.geometry.two_two.size(), Eq(N3_22_before+1))
+		<< "(2,2) simplices did not increase by 1.";
 
-    EXPECT_THAT(universe_.geometry.one_three.size(), Eq(N3_13_before))
-        << "(1,3) simplices changed.";
+	EXPECT_THAT(universe_.geometry.one_three.size(), Eq(N3_13_before))
+		<< "(1,3) simplices changed.";
 
-    EXPECT_THAT(universe_.geometry.timelike_edges.size(),
-                Eq(timelike_edges_before+1))
-        << "Timelike edges did not increase by 1.";
+	EXPECT_THAT(universe_.geometry.timelike_edges.size(),
+				Eq(timelike_edges_before+1))
+		<< "Timelike edges did not increase by 1.";
 
-    EXPECT_THAT(universe_.geometry.spacelike_edges,
-                Eq(spacelike_edges_before))
-        << "Spacelike edges changed.";
+	EXPECT_THAT(universe_.geometry.spacelike_edges,
+				Eq(spacelike_edges_before))
+		<< "Spacelike edges changed.";
 
-    EXPECT_THAT(universe_.triangulation->number_of_vertices(),
-                Eq(vertices_before))
-        << "The number of vertices changed.";
+	EXPECT_THAT(universe_.triangulation->number_of_vertices(),
+				Eq(vertices_before))
+		<< "The number of vertices changed.";
 }
 
 TEST_F(S3ErgodicMoveTest, MakeA32Move) {
-    universe_ = std::move(make_32_move(std::move(universe_),
-                                       attempted_moves_));
-    std::cout << "Attempted (3,2) moves = " << std::get<1>(attempted_moves_)
-        << std::endl;
+	universe_ = std::move(make_32_move(std::move(universe_),
+									   attempted_moves_));
+	std::cout << "Attempted (3,2) moves = " << std::get<1>(attempted_moves_)
+		<< std::endl;
 
-    // We expect the triangulation to be valid, but not necessarily Delaunay
-    EXPECT_TRUE(universe_.triangulation->tds().is_valid())
-        << "Triangulation is invalid.";
+	// We expect the triangulation to be valid, but not necessarily Delaunay
+	EXPECT_TRUE(universe_.triangulation->tds().is_valid())
+		<< "Triangulation is invalid.";
 
-    EXPECT_THAT(universe_.triangulation->dimension(), Eq(3))
-        << "Triangulation has wrong dimensionality.";
+	EXPECT_THAT(universe_.triangulation->dimension(), Eq(3))
+		<< "Triangulation has wrong dimensionality.";
 
-    EXPECT_TRUE(fix_timeslices(universe_.triangulation))
-        << "Some simplices do not span exactly 1 timeslice.";
+	EXPECT_TRUE(fix_timeslices(universe_.triangulation))
+		<< "Some simplices do not span exactly 1 timeslice.";
 
-    EXPECT_THAT(universe_.geometry.three_one.size(), Eq(N3_31_before))
-        << "(3,1) simplices changed.";
+	EXPECT_THAT(universe_.geometry.three_one.size(), Eq(N3_31_before))
+		<< "(3,1) simplices changed.";
 
-    EXPECT_THAT(universe_.geometry.two_two.size(), Eq(N3_22_before-1))
-        << "(2,2) simplices did not decrease by 1.";
+	EXPECT_THAT(universe_.geometry.two_two.size(), Eq(N3_22_before-1))
+		<< "(2,2) simplices did not decrease by 1.";
 
-    EXPECT_THAT(universe_.geometry.one_three.size(), Eq(N3_13_before))
-        << "(1,3) simplices changed.";
+	EXPECT_THAT(universe_.geometry.one_three.size(), Eq(N3_13_before))
+		<< "(1,3) simplices changed.";
 
-    EXPECT_THAT(universe_.geometry.timelike_edges.size(),
-                Eq(timelike_edges_before-1))
-        << "Timelike edges did not decrease by 1.";
+	EXPECT_THAT(universe_.geometry.timelike_edges.size(),
+				Eq(timelike_edges_before-1))
+		<< "Timelike edges did not decrease by 1.";
 
-    EXPECT_THAT(universe_.geometry.spacelike_edges, Eq(spacelike_edges_before))
-        << "Spacelike edges changed.";
+	EXPECT_THAT(universe_.geometry.spacelike_edges, Eq(spacelike_edges_before))
+		<< "Spacelike edges changed.";
 
-    EXPECT_THAT(universe_.triangulation->number_of_vertices(),
-                Eq(vertices_before))
-        << "The number of vertices changed.";
+	EXPECT_THAT(universe_.triangulation->number_of_vertices(),
+				Eq(vertices_before))
+		<< "The number of vertices changed.";
 }
 
 TEST_F(S3ErgodicMoveTest, MakeA26Move) {
-    universe_ = std::move(make_26_move(std::move(universe_),
-                                       attempted_moves_));
-    std::cout << "Attempted (2,6) moves = " << std::get<2>(attempted_moves_)
-        << std::endl;
+	universe_ = std::move(make_26_move(std::move(universe_),
+									   attempted_moves_));
+	std::cout << "Attempted (2,6) moves = " << std::get<2>(attempted_moves_)
+		<< std::endl;
 
-    EXPECT_TRUE(universe_.triangulation->tds().is_valid(true))
-        << "Triangulation is invalid.";
+	EXPECT_TRUE(universe_.triangulation->tds().is_valid(true))
+		<< "Triangulation is invalid.";
 
-    EXPECT_THAT(universe_.triangulation->dimension(), Eq(3))
-        << "Triangulation has wrong dimensionality.";
+	EXPECT_THAT(universe_.triangulation->dimension(), Eq(3))
+		<< "Triangulation has wrong dimensionality.";
 
-    EXPECT_TRUE(fix_timeslices(universe_.triangulation))
-        << "Some simplices do not span exactly 1 timeslice.";
+	EXPECT_TRUE(fix_timeslices(universe_.triangulation))
+		<< "Some simplices do not span exactly 1 timeslice.";
 
-    EXPECT_THAT(universe_.geometry.three_one.size(), Eq(N3_31_before+2))
-        << "(3,1) simplices did not increase by 2.";
+	EXPECT_THAT(universe_.geometry.three_one.size(), Eq(N3_31_before+2))
+		<< "(3,1) simplices did not increase by 2.";
 
-    EXPECT_THAT(universe_.geometry.two_two.size(), Eq(N3_22_before))
-        << "(2,2) simplices changed.";
+	EXPECT_THAT(universe_.geometry.two_two.size(), Eq(N3_22_before))
+		<< "(2,2) simplices changed.";
 
-    EXPECT_THAT(universe_.geometry.one_three.size(), Eq(N3_13_before+2))
-        << "(1,3) simplices did not increase by 2.";
+	EXPECT_THAT(universe_.geometry.one_three.size(), Eq(N3_13_before+2))
+		<< "(1,3) simplices did not increase by 2.";
 
-    EXPECT_THAT(universe_.geometry.timelike_edges.size(),
-                Eq(timelike_edges_before+2))
-        << "Timelike edges did not increase by 2.";
+	EXPECT_THAT(universe_.geometry.timelike_edges.size(),
+				Eq(timelike_edges_before+2))
+		<< "Timelike edges did not increase by 2.";
 
-    EXPECT_THAT(universe_.geometry.spacelike_edges,
-                Eq(spacelike_edges_before+3))
-        << "Spacelike edges did not increase by 3.";
+	EXPECT_THAT(universe_.geometry.spacelike_edges,
+				Eq(spacelike_edges_before+3))
+		<< "Spacelike edges did not increase by 3.";
 
-    EXPECT_THAT(universe_.geometry.vertices.size(), Eq(vertices_before+1))
-        << "A vertex was not added to the triangulation.";
+	EXPECT_THAT(universe_.geometry.vertices.size(), Eq(vertices_before+1))
+		<< "A vertex was not added to the triangulation.";
 }
 
 TEST_F(S3ErgodicMoveTest, MakeA62Move) {
-    universe_ = std::move(make_62_move(std::move(universe_),
-                                     attempted_moves_));
-    std::cout << "Attempted (6,2) moves = " << std::get<3>(attempted_moves_)
-                                          << std::endl;
+    bool move_made;
+	universe_ = std::move(make_62_move(std::move(universe_),
+									 attempted_moves_, move_made));
+	std::cout << "Attempted (6,2) moves = " << std::get<3>(attempted_moves_)
+										  << std::endl;
 
-    // We expect the triangulation to be valid, but not necessarily Delaunay
-    EXPECT_TRUE(universe_.triangulation->tds().is_valid())
-        << "Triangulation is invalid.";
+	
+	
+	// We expect the triangulation to be valid, but not necessarily Delaunay
+	EXPECT_TRUE(universe_.triangulation->tds().is_valid())
+		<< "Triangulation is invalid.";
 
-    EXPECT_THAT(universe_.triangulation->dimension(), Eq(3))
-        << "Triangulation has wrong dimensionality.";
+	EXPECT_THAT(universe_.triangulation->dimension(), Eq(3))
+		<< "Triangulation has wrong dimensionality.";
 
-    EXPECT_TRUE(fix_timeslices(universe_.triangulation))
-        << "Some simplices do not span exactly 1 timeslice.";
+	EXPECT_TRUE(fix_timeslices(universe_.triangulation))
+		<< "Some simplices do not span exactly 1 timeslice.";
+	
+	//tests when there exist no (6, 2) moves
+	if (!move_made){
+		EXPECT_THAT(universe_.geometry.three_one.size(), Eq(N3_31_before))
+			<< "(3,1) simplices changed even though no move was made.";
 
-    EXPECT_THAT(universe_.geometry.three_one.size(), Eq(N3_31_before - 2))
-        << "(3,1) simplices did not decrease by 2.";
+		EXPECT_THAT(universe_.geometry.two_two.size(), Eq(N3_22_before))
+			<< "(2,2) simplices changed even though no move was made.";
 
-    EXPECT_THAT(universe_.geometry.two_two.size(), Eq(N3_22_before))
-        << "(2,2) simplices changed.";
+		EXPECT_THAT(universe_.geometry.one_three.size(), Eq(N3_13_before))
+			<< "(1,3) simplices changed even though no move was made.";
 
-    EXPECT_THAT(universe_.geometry.one_three.size(), Eq(N3_13_before - 2))
-        << "(1,3) simplices did not decrease by 2.";
+		EXPECT_THAT(universe_.geometry.timelike_edges.size(),
+					Eq(timelike_edges_before))
+			<< "Timelike edges changed even though no move was made.";
 
-    EXPECT_THAT(universe_.geometry.timelike_edges.size(),
-                Eq(timelike_edges_before - 2))
-        << "Timelike edges did not decrease by 2.";
+		EXPECT_THAT(universe_.geometry.spacelike_edges,
+					Eq(spacelike_edges_before))
+			<< "Spacelike edges changed even though no move was made.";
 
-    EXPECT_THAT(universe_.geometry.spacelike_edges,
-                Eq(spacelike_edges_before - 3))
-        << "Spacelike edges did not decrease by 3.";
+		EXPECT_THAT(universe_.geometry.vertices.size(), Eq(vertices_before))
+			<< "The number of vertices changed even though no move was made.";
+		
+	}
+	else{
+		EXPECT_THAT(universe_.geometry.three_one.size(), Eq(N3_31_before - 2))
+			<< "(3,1) simplices did not decrease by 2.";
 
-    EXPECT_THAT(universe_.geometry.vertices.size(), Eq(vertices_before - 1))
-        << "The number of vertices did not decrease by 1.";
+		EXPECT_THAT(universe_.geometry.two_two.size(), Eq(N3_22_before))
+			<< "(2,2) simplices changed.";
+
+		EXPECT_THAT(universe_.geometry.one_three.size(), Eq(N3_13_before - 2))
+			<< "(1,3) simplices did not decrease by 2.";
+
+		EXPECT_THAT(universe_.geometry.timelike_edges.size(),
+					Eq(timelike_edges_before - 2))
+			<< "Timelike edges did not decrease by 2.";
+
+		EXPECT_THAT(universe_.geometry.spacelike_edges,
+					Eq(spacelike_edges_before - 3))
+			<< "Spacelike edges did not decrease by 3.";
+
+		EXPECT_THAT(universe_.geometry.vertices.size(), Eq(vertices_before - 1))
+			<< "The number of vertices did not decrease by 1.";
+	}
 }

--- a/unittests/S3ErgodicMovesTest.cpp
+++ b/unittests/S3ErgodicMovesTest.cpp
@@ -194,6 +194,7 @@ TEST_F(S3ErgodicMoveTest, MakeA26Move) {
 }
 
 TEST_F(S3ErgodicMoveTest, MakeA62Move) {
+    
     bool move_made;
 	universe_ = std::move(make_62_move(std::move(universe_),
 									 attempted_moves_, move_made));


### PR DESCRIPTION
Added testing for when (6, 2) moves do not exist within a triangulation. For completeness, maybe we should include these tests for other ergodic moves.