### PR TITLE
Give FoliatedTriangulation a copy constructor

### DIFF
--- a/include/Foliated_triangulation.hpp
+++ b/include/Foliated_triangulation.hpp
@@ -139,6 +139,11 @@ class FoliatedTriangulation<3> final : private Delaunay3
       , m_min_timevalue{find_min_timevalue(m_points)}
   {}
 
+
+  /// @brief Copy Constructor
+  FoliatedTriangulation(FoliatedTriangulation const& other)
+      : FoliatedTriangulation(static_cast<Delaunay3 const&>(other)) {}
+
   /// @return A mutable reference to the Delaunay base class
   auto delaunay() -> Delaunay3& { return *this; }
 


### PR DESCRIPTION
Private data members within FoliatedTriangulation store iterators to parts of the Delaunay triangulation data member. When that triangulation is copied, those references need to be updated also.

This should resolve some of the move command test failures.