### PR TITLE
Restore cout streambuf in test

### DIFF
--- a/tests/Utilities_test.cpp
+++ b/tests/Utilities_test.cpp
@@ -21,8 +21,9 @@ SCENARIO("Various string/stream/time utilities", "[utility]")
     WHEN("Operator<< is invoked.")
     {
       stringstream buffer;
-      cout.rdbuf(buffer.rdbuf());
+      std::streambuf * backup = cout.rdbuf(buffer.rdbuf());
       cout << this_topology;
+      cout.rdbuf(backup);
       THEN("The output is correct.")
       {
         CHECK_THAT(buffer.str(), Catch::Equals("spherical"));


### PR DESCRIPTION
This will keep the Utilities test from causing subsequent tests to fail, by restoring the original stream buffer inside `std::cout`