### PR TITLE
ci: align repository status reporting with main

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,6 @@
 ---
 codecov:
+  branch: main
   notify:
     require_ci_to_pass: false
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,9 +14,9 @@ name: "CodeQL Advanced"
 
 "on":
   push:
-    branches: ["main", "gh-pages"]
+    branches: ["main"]
   pull_request:
-    branches: ["main", "gh-pages"]
+    branches: ["main"]
   schedule:
     - cron: '29 0 * * 2'
 

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,5 +1,5 @@
 ---
-name: Doxygen GitHub Pages Deploy Action
+name: Doxygen
 
 "on":
   push:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 **Quantize spacetime on your laptop.**
 
+[![License](https://badgen.net/github/license/acgetchell/CDT-plusplus)](https://github.com/acgetchell/CDT-plusplus/blob/main/LICENSE.md)
 [![CI](https://github.com/acgetchell/CDT-plusplus/actions/workflows/ci.yml/badge.svg)](https://github.com/acgetchell/CDT-plusplus/actions/workflows/ci.yml)
+[![Documentation](https://github.com/acgetchell/CDT-plusplus/actions/workflows/doxygen.yml/badge.svg)](https://www.adamgetchell.org/CDT-plusplus/)
 [![codecov](https://codecov.io/gh/acgetchell/CDT-plusplus/branch/main/graph/badge.svg)](https://codecov.io/gh/acgetchell/CDT-plusplus)
 
 ![Small foliated Delaunay triangulation](docs/images/S3-7-27528-I1-R1.png "7 timeslices 27528 simplices")


### PR DESCRIPTION
- Treat main as Codecov’s default branch and exclude generated Pages content from CodeQL.
- Add license and documentation badges and shorten the Doxygen workflow label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added License and Documentation status badges to the README.

* **Chores**
  * Updated coverage reporting to target the main branch.
  * Restricted CodeQL checks to changes targeting the main branch.
  * Simplified the displayed name of the documentation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->