### PR TITLE
fix(experiments): harden optional Python experiment lifecycle

### DIFF
--- a/scripts/optimize_initialize.py
+++ b/scripts/optimize_initialize.py
@@ -8,12 +8,65 @@ import re
 import sys
 from pathlib import Path
 from subprocess import check_output as qx
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Callable, Mapping, Sequence
 
 MAX_RANDOM_SEED = (1 << 64) - 1
+PARAMETER_PAIRS = tuple((initial_radius, spacing) for initial_radius in range(1, 4) for spacing in (1.0, 1.5, 2.0))
+
+
+class _Experiment(Protocol):
+    """Comet operations used by the historical parameter sweep."""
+
+    def log_parameters(self, parameters: Mapping[str, int | float]) -> object:
+        """Record the inputs used by one initializer run."""
+        ...
+
+    def log_metric(self, name: str, value: float) -> object:
+        """Record a numeric result."""
+        ...
+
+    def log_other(self, name: str, value: int) -> object:
+        """Record non-metric result metadata."""
+        ...
+
+    def log_figure(self, *, figure_name: str, figure: object) -> object:
+        """Record the volume profile plot."""
+        ...
+
+    def end(self) -> object:
+        """Close the online experiment."""
+        ...
+
+
+class _Plotter(Protocol):
+    """Matplotlib operations used by the historical parameter sweep."""
+
+    def plot(self, x_values: list[int], y_values: list[int]) -> object:
+        """Plot the volume profile."""
+        ...
+
+    def xlabel(self, label: str) -> object:
+        """Label the horizontal axis."""
+        ...
+
+    def ylabel(self, label: str) -> object:
+        """Label the vertical axis."""
+        ...
+
+    def title(self, label: str) -> object:
+        """Set the plot title."""
+        ...
+
+    def grid(self, *, visible: bool) -> object:
+        """Configure the plot grid."""
+        ...
+
+    def clf(self) -> object:
+        """Clear the current figure."""
+        ...
 
 
 def _parse_seed(value: str) -> int:
@@ -80,7 +133,7 @@ def _initializer_command(
     initialize_binary: Path,
     hyper_params: Mapping[str, int],
     initial_radius: int,
-    radial_factor: float,
+    foliation_spacing: float,
 ) -> list[str]:
     """Build one replayable initializer invocation."""
     return [
@@ -93,39 +146,41 @@ def _initializer_command(
         "-i",
         str(initial_radius),
         "-f",
-        str(radial_factor),
+        str(foliation_spacing),
         "--seed",
         str(hyper_params["seed"]),
     ]
 
 
-def _run_experiments(initialize_binary: Path, api_key: str, seed: int) -> None:
-    """Run the historical Comet parameter sweep."""
-    import matplotlib.pyplot as plt  # noqa: PLC0415
-    import numpy as np  # noqa: PLC0415
-    from comet_ml import Experiment  # noqa: PLC0415
-
-    parameters = [(initial_radius, spacing) for initial_radius in range(1, 4) for spacing in np.arange(1, 2.5, 0.5)]
-
-    for parameter_pair in parameters:
-        experiment = Experiment(api_key=api_key, project_name="cdt-plusplus")
+def _run_parameter_sweep(
+    initialize_binary: Path,
+    seed: int,
+    experiment_factory: Callable[[], _Experiment],
+    initializer_runner: Callable[[list[str]], str],
+    plotter: _Plotter,
+) -> None:
+    """Run the parameter sweep through injected initializer and Comet boundaries."""
+    for initial_radius, foliation_spacing in PARAMETER_PAIRS:
+        experiment = experiment_factory()
         try:
             hyper_params = {"simplices": 12000, "foliations": 12, "seed": seed}
-            experiment.log_parameters(hyper_params)
-            init_radius = parameter_pair[0]
-            radial_factor = parameter_pair[1]
+            experiment.log_parameters(
+                {
+                    **hyper_params,
+                    "initial_radius": initial_radius,
+                    "foliation_spacing": foliation_spacing,
+                }
+            )
 
             command = _initializer_command(
                 initialize_binary,
                 hyper_params,
-                initial_radius=init_radius,
-                radial_factor=radial_factor,
+                initial_radius=initial_radius,
+                foliation_spacing=foliation_spacing,
             )
             print(command)
 
-            # The executable and numeric parameters are repository-controlled.
-            output = qx(command, text=True)  # noqa: S603
-
+            output = initializer_runner(command)
             final_simplices, graph = _parse_initializer_output(output)
 
             min_timeslice = min(timeslice for timeslice, _ in graph)
@@ -133,8 +188,8 @@ def _run_experiments(initialize_binary: Path, api_key: str, seed: int) -> None:
             result = (final_simplices, min_timeslice, max_timeslice)
 
             print(result)
-            print(f"Initial radius is: {init_radius}")
-            print(f"Radial factor is: {radial_factor}")
+            print(f"Initial radius is: {initial_radius}")
+            print(f"Foliation spacing is: {foliation_spacing}")
             for timeslice, volume in graph:
                 print(f"Timeslice {timeslice} has {volume} spacelike faces.")
             print()
@@ -147,15 +202,30 @@ def _run_experiments(initialize_binary: Path, api_key: str, seed: int) -> None:
 
             timeslices = [timeslice for timeslice, _ in graph]
             volumes = [volume for _, volume in graph]
-            plt.plot(timeslices, volumes)
-            plt.xlabel("Timeslice")
-            plt.ylabel("Volume (spacelike faces)")
-            plt.title("Volume Profile")
-            plt.grid(visible=True)
-            experiment.log_figure(figure_name="Volume per Timeslice", figure=plt)
-            plt.clf()
+            plotter.plot(timeslices, volumes)
+            plotter.xlabel("Timeslice")
+            plotter.ylabel("Volume (spacelike faces)")
+            plotter.title("Volume Profile")
+            plotter.grid(visible=True)
+            experiment.log_figure(figure_name="Volume per Timeslice", figure=plotter)
+            plotter.clf()
         finally:
             experiment.end()
+
+
+def _run_experiments(initialize_binary: Path, api_key: str, seed: int) -> None:
+    """Run the historical Comet parameter sweep."""
+    import matplotlib.pyplot as plt  # noqa: PLC0415
+    from comet_ml import Experiment  # noqa: PLC0415
+
+    def experiment_factory() -> _Experiment:
+        return Experiment(api_key=api_key, project_name="cdt-plusplus")
+
+    def initializer_runner(command: list[str]) -> str:
+        # The executable and numeric parameters are repository-controlled.
+        return qx(command, text=True)  # noqa: S603
+
+    _run_parameter_sweep(initialize_binary, seed, experiment_factory, initializer_runner, plt)
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/scripts/tests/test_experiment_imports.py
+++ b/scripts/tests/test_experiment_imports.py
@@ -1,0 +1,44 @@
+"""Import-safety tests for optional experiment scripts."""
+
+from __future__ import annotations
+
+import builtins
+import importlib.util
+import unittest
+from unittest.mock import patch
+
+
+class ExperimentImportTests(unittest.TestCase):
+    """Verify imports do not cross optional or executable boundaries."""
+
+    def test_experiment_scripts_import_without_running_experiments(self) -> None:
+        """Importing either script needs no ML, plotting, Comet, or subprocess work."""
+        optional_modules = {"comet_ml", "matplotlib", "numpy", "tensorflow"}
+        real_import = builtins.__import__
+
+        def guarded_import(
+            name: str,
+            global_namespace: dict[str, object] | None = None,
+            local_namespace: dict[str, object] | None = None,
+            fromlist: tuple[str, ...] = (),
+            level: int = 0,
+        ) -> object:
+            if name.partition(".")[0] in optional_modules:
+                message = f"optional dependency imported: {name}"
+                raise AssertionError(message)
+            return real_import(name, global_namespace, local_namespace, fromlist, level)
+
+        with patch("builtins.__import__", side_effect=guarded_import), patch("subprocess.Popen") as popen:
+            for module_name in ("scripts.optimize_initialize", "scripts.mnist_experiment"):
+                spec = importlib.util.find_spec(module_name)
+                if spec is None or spec.loader is None:
+                    self.fail(f"could not find an import loader for {module_name}")
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+                self.assertTrue(callable(module.main))
+
+        popen.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_optimize_initialize.py
+++ b/scripts/tests/test_optimize_initialize.py
@@ -5,8 +5,17 @@ from __future__ import annotations
 import argparse
 import unittest
 from pathlib import Path
+from unittest.mock import Mock, patch
 
-from scripts.optimize_initialize import _initializer_binary, _initializer_command, _parse_args, _parse_initializer_output, _parse_seed
+from scripts.optimize_initialize import (
+    PARAMETER_PAIRS,
+    _initializer_binary,
+    _initializer_command,
+    _parse_args,
+    _parse_initializer_output,
+    _parse_seed,
+    _run_parameter_sweep,
+)
 
 
 class OptimizeInitializeTests(unittest.TestCase):
@@ -71,9 +80,56 @@ Final number of simplices: 92"""
             Path("initialize"),
             {"simplices": 12000, "foliations": 12, "seed": 92},
             initial_radius=1,
-            radial_factor=1.5,
+            foliation_spacing=1.5,
         )
-        self.assertEqual(command[-2:], ["--seed", "92"])
+        self.assertEqual(
+            command,
+            ["initialize", "-s", "-n", "12000", "-t", "12", "-i", "1", "-f", "1.5", "--seed", "92"],
+        )
+
+    def test_parameter_sweep_records_actual_geometry_and_ends_experiment(self) -> None:
+        """Each successful run records its variable inputs and closes Comet."""
+        experiments = [Mock() for _ in PARAMETER_PAIRS]
+        experiment_factory = Mock(side_effect=experiments)
+        initializer_runner = Mock(
+            return_value="""Timeslice 1 has 12 spacelike faces.
+Timeslice 2 has 24 spacelike faces.
+Final number of simplices: 12000"""
+        )
+        plotter = Mock()
+
+        with patch("builtins.print"):
+            _run_parameter_sweep(
+                Path("initialize"),
+                92,
+                experiment_factory,
+                initializer_runner,
+                plotter,
+            )
+
+        for experiment, (initial_radius, foliation_spacing) in zip(experiments, PARAMETER_PAIRS, strict=True):
+            experiment.log_parameters.assert_called_once_with(
+                {
+                    "simplices": 12000,
+                    "foliations": 12,
+                    "seed": 92,
+                    "initial_radius": initial_radius,
+                    "foliation_spacing": foliation_spacing,
+                }
+            )
+            experiment.end.assert_called_once_with()
+
+        initializer_runner.assert_any_call(["initialize", "-s", "-n", "12000", "-t", "12", "-i", "3", "-f", "2.0", "--seed", "92"])
+
+    def test_parameter_sweep_ends_experiment_when_initializer_fails(self) -> None:
+        """A failed initializer cannot leave its Comet experiment open."""
+        experiment = Mock()
+        initializer_runner = Mock(side_effect=RuntimeError("initializer failed"))
+
+        with patch("builtins.print"), self.assertRaisesRegex(RuntimeError, "initializer failed"):
+            _run_parameter_sweep(Path("initialize"), 92, Mock(return_value=experiment), initializer_runner, Mock())
+
+        experiment.end.assert_called_once_with()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- record geometry parameters for every initializer optimization run
- isolate initializer and Comet boundaries from import-time behavior
- close each Comet experiment after successful or failed execution

Fixes #107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved initializer optimization reliability and flexibility.
  * Parameter sweeps now record geometry settings for each experiment.
  * Experiments are properly closed even when an initialization run fails.

* **Testing**
  * Added coverage to verify parameter logging and cleanup behavior.
  * Added checks that optional experiment scripts can be imported without launching experiments or loading heavy dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->