### PR TITLE
refactor(api)!: normalize public declarations under cdt

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -5,7 +5,7 @@ set minimum-version := "1.57.0"
 set shell := ["bash", "-euo", "pipefail", "-c"]
 
 just_version := "1.57.0"
-uv_version := "0.11.30"
+uv_version := "0.11.31"
 git_cliff_version := "2.13.1"
 pinact_version := "4.1.0"
 pinact_module := "github.com/suzuki-shunsuke/pinact/v4/cmd/pinact@v" + pinact_version

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Quantize spacetime on your laptop.**
 
-[![DOI](https://zenodo.org/badge/11688464.svg)](https://doi.org/10.5281/zenodo.21487044)
+[![DOI](https://badgen.net/badge/DOI/10.5281%2Fzenodo.21487043/blue)](https://doi.org/10.5281/zenodo.21487043)
 [![GitHub stars](https://badgen.net/github/stars/acgetchell/CDT-plusplus)](https://github.com/acgetchell/CDT-plusplus/stargazers)
 [![License](https://badgen.net/github/license/acgetchell/CDT-plusplus)](https://github.com/acgetchell/CDT-plusplus/blob/main/LICENSE.md)
 [![CI](https://github.com/acgetchell/CDT-plusplus/actions/workflows/ci.yml/badge.svg)](https://github.com/acgetchell/CDT-plusplus/actions/workflows/ci.yml)
@@ -136,6 +136,19 @@ and invokes the same build contract directly, without requiring Just:
 ```bash
 ./scripts/pkgx-build.sh
 ```
+
+To expose the same dependency-build tools to an interactive shell, source the
+reusable environment script:
+
+```bash
+source scripts/pkgx-env.sh
+```
+
+In CLion, open **Settings | Build, Execution, Deployment | Toolchains**, select
+the local toolchain, choose **Add environment | From file**, and select
+`scripts/pkgx-env.sh`. The script supplies the pkgx tool environment and points
+`VCPKG_ROOT` at the repository-owned `.cache/vcpkg` checkout while keeping CGAL
+and the other project libraries under vcpkg control.
 
 pkgx does not install CGAL or any other project library; those remain owned by the pinned vcpkg manifest. The
 underlying `./scripts/build.sh` and `scripts\build.bat` entry points remain available for troubleshooting and native

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Arbitrary-precision numbers and functions are by [MPFR] and [GMP].
 [doctest] provides [BDD]/[TDD].
 [vcpkg] provides library management and building.
 [Doxygen] provides automated document generation.
+The supported C++ namespace and per-header contract are recorded in the
+[C++ API boundary](docs/api-boundary.md).
 [{fmt}] provides a safe and fast alternative to `iostream`.
 [spdlog] provides fast, multithreaded logging.
 [CometML] provides experiment tracking for the optional Python workflows.
@@ -465,9 +467,11 @@ The command uses an isolated `build/coverage` CMake tree and writes the filtered
 LCOV tracefile to `build/coverage.info` and the browsable report to
 `build/coverage-html/index.html`. Only project-owned `include/` and `src/`
 paths are retained, consistently excluding tests, generated files, system
-headers, and vcpkg dependencies. If coverage collection fails, verify that
-`g++ -dumpfullversion -dumpversion` and `gcov --version` report the same major
-version.
+headers, and vcpkg dependencies. Reports include line and branch coverage;
+function coverage is disabled because GCC can emit inconsistent function and
+line records for generated lambda bodies. If coverage collection fails, verify
+that `g++ -dumpfullversion -dumpversion` and `gcov --version` report the same
+major version.
 
 The Codecov workflow runs this recipe, uploads only `build/coverage.info` with
 OIDC, and preserves both reports as a 14-day GitHub Actions artifact for local

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -954,7 +954,9 @@ EXCLUDE_PATTERNS       =
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        =
+EXCLUDE_SYMBOLS        = cdt::detail::* \
+                         cdt::*::detail::* \
+                         cdt::experimental::*
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include

--- a/docs/api-boundary.md
+++ b/docs/api-boundary.md
@@ -1,0 +1,67 @@
+# C++ API boundary
+
+CDT++ 1.0 uses `cdt` as the sole root namespace for project-owned C++
+declarations. Component namespaces describe a domain, while any nested
+`detail` namespace is an implementation contract and is not supported for
+downstream callers. The namespace is a maintenance signal rather than an
+access-control mechanism.
+
+The public headers do not contain namespace-wide `using` directives. The only
+project macro intended for callers' preprocessing environment is
+`CDT_PRETTY_FUNCTION`, which normalizes compiler function-name spellings and is
+project-prefixed because macros cannot be namespaced. Include guards and the
+platform-required `NOMINMAX` definition are preprocessing exceptions rather
+than C++ API declarations. The formatter specializations remain in `fmt`, as
+required by that library's customization contract.
+
+## Header classification
+
+| Header | Supported surface | Internal, customization, or experimental surface |
+| --- | --- | --- |
+| `Apply_move.hpp` | `cdt::apply_move` | None |
+| `Ergodic_moves_3.hpp` | `cdt::ergodic_moves` aliases plus `null_move`, `do_*_move`, and `propose_*_move` | Every declaration in `cdt::ergodic_moves::detail`, including raw CGAL flips, cavity recognition, collection helpers, `bistellar_flip`, and `check_move` |
+| `Foliated_triangulation.hpp` | Root CGAL interop aliases and `Cell_type`; construction, inspection, repair, and `FoliatedTriangulation` declarations in `cdt::foliated_triangulations` | Generic constraints and repair limits in `cdt::detail`; the component declarations are the supported advanced triangulation API |
+| `Formatters.hpp` | `fmt::formatter<CGAL::Point_3<...>>` | Supported external-library customization point |
+| `Geometry.hpp` | `cdt::Geometry` and `cdt::Geometry_3` | None |
+| `Manifold.hpp` | `cdt::manifolds::make_causal_vertices`, `Manifold`, and `Manifold_3` | None |
+| `Metropolis.hpp` | `cdt::MoveStrategy` Metropolis specialization and `cdt::Metropolis_3` | Private members and nested types are implementation details |
+| `Move_always.hpp` | `cdt::MoveStrategy` move-always specialization and `cdt::MoveAlways_3` | Private members are implementation details |
+| `Move_command.hpp` | `cdt::MoveCommand` | Private queue and counter types are implementation details |
+| `Move_strategy.hpp` | `cdt::Strategies` and `cdt::MoveStrategy` | None |
+| `Move_tracker.hpp` | Move enumeration, counters, conversion, and sampling in `cdt::move_tracker` | None |
+| `Mpfr_value.hpp` | Scoped MPFR value and operations in `cdt::mpfr_values` | None |
+| `Periodic_3_complex.hpp` | None | Legacy prototype in `cdt::experimental::periodic_complex`; unsupported and retained only for archival source access |
+| `Periodic_3_triangulations.hpp` | None | Legacy prototype in `cdt::experimental::periodic_triangulations`; unsupported and retained only for archival source access |
+| `Random.hpp` | Random engine, seed/stream types, and named streams in `cdt` | None |
+| `Runtime_config.hpp` | Validated configuration values and factories in `cdt::runtime_config` | Parsing helpers in `cdt::runtime_config::detail` |
+| `S3Action.hpp` | Physical parameters and action functions in `cdt::s3_action` | None |
+| `Settings.hpp` | Scalar types and named constants in `cdt` | Project-prefixed preprocessing exception described above |
+| `Torus_d.hpp` | None | Legacy prototype in `cdt::experimental::torus`; unsupported and retained only for archival source access |
+| `Triangulation_traits.hpp` | None | CGAL assembly traits in `cdt::detail`; supported aliases are published by `Foliated_triangulation.hpp` |
+| `Utilities.hpp` | `cdt::topology_type` and persistence, reproducibility, random-distribution, logging, and conversion operations in `cdt::utilities` | Serialization and parsing machinery in `cdt::utilities::detail` |
+
+Tests that name `detail` are deliberate white-box tests for mutation
+failure-atomicity and malformed-handle rejection. Test access does not promote
+those declarations into the supported API.
+
+The supported-header compile contract intentionally excludes `experimental`.
+In particular, the periodic prototypes still depend on CGAL interfaces that
+are absent or incompatible in CGAL 6.2; issue #102 owns that integration work.
+Their presence under `include/` preserves archival source access, not a promise
+that they are usable downstream.
+
+## Compatibility policy
+
+This namespace normalization is the source-compatibility boundary for the
+final 1.0 release. Repository production code, tests, and documented examples
+were the only callers found for the pre-1.0 global and unrelated top-level
+namespaces. Compatibility aliases would reintroduce precisely those global
+names and would leave an indefinite archival burden, so no deprecated aliases
+are provided. Downstream source must qualify project names through `cdt`.
+
+The project publishes no stable binary ABI: its library surface is templates
+and inline headers, and the CMake build produces executables rather than a
+versioned binary library. `BUILD_SHARED_LIBS` alone does not establish an ABI
+promise. The supported contract is C++23 source compatibility within the 1.0
+surface documented here; `detail` and `experimental` declarations may change
+without compatibility shims.

--- a/docs/ergodic-moves.md
+++ b/docs/ergodic-moves.md
@@ -78,7 +78,8 @@ The fixed boundary and Euler relation then force every tracked count delta to
 zero.
 
 These derivations agree with the source's f-vectors (71)-(73) but do not call
-`ergodic_moves::check_move()` or any production count-delta helper.
+`cdt::ergodic_moves::detail::check_move()` or any production count-delta
+helper.
 
 ## Verification record
 

--- a/include/Apply_move.hpp
+++ b/include/Apply_move.hpp
@@ -14,21 +14,25 @@
 #include <functional>
 #include <utility>
 
-/**
- * \brief An applicative function similar to std::apply on a manifold
- * \tparam ManifoldType The type (topology, dimensionality) of manifold
- * \tparam ExpectedType The result type of the move on the manifold
- * \tparam FunctionType The type of move applied to the manifold
- * \param t_manifold The manifold on which to make the Pachner move
- * \param t_move The Pachner move
- * \param arguments Explicit dependencies forwarded to the move
- * \return The expected or unexpected result in a std::expected<T,E>
- */
-template <typename ManifoldType, typename FunctionType, typename... Arguments>
-auto constexpr apply_move(ManifoldType const& t_manifold, FunctionType t_move,
-                          Arguments&&... arguments) -> decltype(auto)
+namespace cdt
 {
-  return std::invoke(t_move, t_manifold, std::forward<Arguments>(arguments)...);
-}
+  /**
+   * \brief An applicative function similar to std::apply on a manifold
+   * \tparam ManifoldType The type (topology, dimensionality) of manifold
+   * \tparam ExpectedType The result type of the move on the manifold
+   * \tparam FunctionType The type of move applied to the manifold
+   * \param t_manifold The manifold on which to make the Pachner move
+   * \param t_move The Pachner move
+   * \param arguments Explicit dependencies forwarded to the move
+   * \return The expected or unexpected result in a std::expected<T,E>
+   */
+  template <typename ManifoldType, typename FunctionType, typename... Arguments>
+  auto constexpr apply_move(ManifoldType const& t_manifold, FunctionType t_move,
+                            Arguments&&... arguments) -> decltype(auto)
+  {
+    return std::invoke(t_move, t_manifold,
+                       std::forward<Arguments>(arguments)...);
+  }
+}  // namespace cdt
 
 #endif  // CDT_PLUSPLUS_APPLY_MOVE_HPP

--- a/include/Ergodic_moves_3.hpp
+++ b/include/Ergodic_moves_3.hpp
@@ -31,7 +31,7 @@
 #include "Manifold.hpp"
 #include "Move_tracker.hpp"
 
-namespace ergodic_moves
+namespace cdt::ergodic_moves
 {
   using Manifold         = manifolds::Manifold_3;
   using Expected         = std::expected<Manifold, std::string>;
@@ -229,6 +229,52 @@ namespace ergodic_moves
             return point_less(left->point(), right->point());
           });
     }
+
+    [[nodiscard]] inline auto try_23_move(Delaunay&          triangulation,
+                                          Cell_handle const& to_be_moved)
+        -> bool;
+
+    [[nodiscard]] inline auto try_32_move(Delaunay&          triangulation,
+                                          Edge_handle const& to_be_moved)
+        -> bool;
+
+    [[nodiscard]] inline auto find_adjacent_31_cell(Cell_handle const& cell)
+        -> std::optional<int>;
+
+    [[nodiscard]] inline auto is_62_movable(Delaunay const&      triangulation,
+                                            Vertex_handle const& candidate)
+        -> bool;
+
+    template <std::uniform_random_bit_generator Generator>
+    [[nodiscard]] inline auto try_62_move(Delaunay const& source_triangulation,
+                                          Vertex_handle const source_candidate,
+                                          Generator&          generator)
+        -> std::optional<Delaunay>;
+
+    [[nodiscard]] inline auto incident_cells_from_edge(
+        Delaunay const& triangulation, Edge_handle const& edge)
+        -> std::optional<Cell_container>;
+
+    [[nodiscard]] inline auto find_bistellar_flip_location(
+        Delaunay const& triangulation, Edge_handle const& candidate)
+        -> std::optional<Cell_container>;
+
+    [[nodiscard]] inline auto bistellar_flip(
+        Delaunay const& source_triangulation, Edge_handle source_edge,
+        Vertex_handle source_top, Vertex_handle source_bottom)
+        -> std::optional<Delaunay>;
+
+    [[nodiscard]] inline auto find_pivot_edge(Delaunay const& triangulation,
+                                              Edge_container const& edges)
+        -> std::optional<Edge_handle>;
+
+    [[nodiscard]] inline auto get_vertices(Cell_container const& cells)
+        -> Vertex_container;
+
+    [[nodiscard]] inline auto check_move(Manifold const&                before,
+                                         Manifold const&                after,
+                                         move_tracker::move_type const& move)
+        -> bool;
   }  // namespace detail
 
   /// @brief Perform a null move
@@ -246,8 +292,9 @@ namespace ergodic_moves
   /// @returns True if move succeeded
   /// @see
   /// https://doc.cgal.org/latest/TDS_3/classTriangulationDataStructure__3.html#a2ad2941984c1eac5561665700bfd60b4
-  [[nodiscard]] inline auto try_23_move(Delaunay&          triangulation,
-                                        Cell_handle const& to_be_moved) -> bool
+  [[nodiscard]] inline auto detail::try_23_move(Delaunay& triangulation,
+                                                Cell_handle const& to_be_moved)
+      -> bool
   {
     if (to_be_moved == nullptr || triangulation.dimension() != 3 ||
         !triangulation.tds().is_cell(to_be_moved) ||
@@ -329,7 +376,7 @@ namespace ergodic_moves
     std::ranges::shuffle(two_two, generator);
     // Try a (2,3) move on successive cells in the sequence
     if (std::ranges::any_of(two_two, [&](auto& cell) {
-          return try_23_move(triangulation, cell);
+          return detail::try_23_move(triangulation, cell);
         }))
     {
       return detail::make_manifold(std::move(triangulation), t_manifold);
@@ -352,7 +399,7 @@ namespace ergodic_moves
         foliated_triangulations::collect_cells<3>(triangulation),
         Cell_type::TWO_TWO);
     auto const candidate = detail::canonical_random_element(two_two, generator);
-    if (candidate && try_23_move(triangulation, *candidate))
+    if (candidate && detail::try_23_move(triangulation, *candidate))
     {
       return detail::make_manifold(std::move(triangulation), t_manifold);
     }
@@ -407,8 +454,9 @@ namespace ergodic_moves
   /// @returns True if the CDT cavity is admissible and CGAL performs the flip
   /// @see
   /// https://doc.cgal.org/latest/TDS_3/classTriangulationDataStructure__3.html#a5837d666e4198f707f862003c1ffa033
-  [[nodiscard]] inline auto try_32_move(Delaunay&          triangulation,
-                                        Edge_handle const& to_be_moved) -> bool
+  [[nodiscard]] inline auto detail::try_32_move(Delaunay& triangulation,
+                                                Edge_handle const& to_be_moved)
+      -> bool
   {
     if (!detail::is_32_movable(triangulation, to_be_moved)) { return false; }
     return triangulation.flip(to_be_moved.first, to_be_moved.second,
@@ -440,7 +488,7 @@ namespace ergodic_moves
     std::ranges::shuffle(timelike_edges, generator);
     // Try a (3,2) move on successive timelike edges in the sequence
     if (std::ranges::any_of(timelike_edges, [&](auto& edge) {
-          return try_32_move(triangulation, edge);
+          return detail::try_32_move(triangulation, edge);
         }))
     {
       return detail::make_manifold(std::move(triangulation), t_manifold);
@@ -462,7 +510,7 @@ namespace ergodic_moves
         foliated_triangulations::collect_edges<3>(triangulation), true);
     auto const candidate =
         detail::canonical_random_element(timelike_edges, generator);
-    if (candidate && try_32_move(triangulation, *candidate))
+    if (candidate && detail::try_32_move(triangulation, *candidate))
     {
       return detail::make_manifold(std::move(triangulation), t_manifold);
     }
@@ -474,8 +522,8 @@ namespace ergodic_moves
   /// with a (1,3) simplex, it checks neighbors for a (3,1) simplex.
   /// @param t_cell The (1,3) simplex that is checked
   /// @returns The integer of the neighboring (3,1) simplex or nullopt
-  [[nodiscard]] inline auto find_adjacent_31_cell(Cell_handle const& t_cell)
-      -> std::optional<int>
+  [[nodiscard]] inline auto detail::find_adjacent_31_cell(
+      Cell_handle const& t_cell) -> std::optional<int>
   {
     if (t_cell == nullptr ||
         !foliated_triangulations::is_cell_type_correct<3>(t_cell) ||
@@ -662,25 +710,15 @@ namespace ergodic_moves
   /// @param t_manifold The simplicial manifold
   /// @param generator Caller-owned generator whose state advances during the
   /// move
-  /// @param only_first_site Whether to examine only one uniformly selected site
   /// @returns The Expected (2,6) moved manifold or an Unexpected
   /// @note The source manifold is unchanged on success and failure.
-
-  template <std::uniform_random_bit_generator Generator>
-  [[nodiscard]] inline auto do_26_move_impl(Manifold const& t_manifold,
-                                            Generator&      generator,
-                                            bool const      only_first_site)
-      -> Expected
-  {
-    return detail::do_26_move_impl(t_manifold, generator, only_first_site,
-                                   detail::accept_post_mutation);
-  }
-
-  /// @brief Perform a (2,6) move using a caller-owned random stream.
   template <std::uniform_random_bit_generator Generator>
   [[nodiscard]] inline auto do_26_move(Manifold const& t_manifold,
                                        Generator&      generator) -> Expected
-  { return do_26_move_impl(t_manifold, generator, false); }
+  {
+    return detail::do_26_move_impl(t_manifold, generator, false,
+                                   detail::accept_post_mutation);
+  }
 
   /// @brief Propose a uniformly selected (2,6) site.
   /// @details Exactly one uniformly selected (1,3) cell is examined. An
@@ -689,7 +727,10 @@ namespace ergodic_moves
   template <std::uniform_random_bit_generator Generator>
   [[nodiscard]] inline auto propose_26_move(Manifold const& t_manifold,
                                             Generator& generator) -> Expected
-  { return do_26_move_impl(t_manifold, generator, true); }
+  {
+    return detail::do_26_move_impl(t_manifold, generator, true,
+                                   detail::accept_post_mutation);
+  }
 
   /// @brief Find a (6,2) move location
   /// @details This function checks to see if a (6,2) move is possible. Starting
@@ -699,9 +740,8 @@ namespace ergodic_moves
   /// @param triangulation The triangulation containing the candidate
   /// @param candidate The vertex to check
   /// @returns True if (6,2) move is possible
-  [[nodiscard]] inline auto is_62_movable(Delaunay const&      triangulation,
-                                          Vertex_handle const& candidate)
-      -> bool
+  [[nodiscard]] inline auto detail::is_62_movable(
+      Delaunay const& triangulation, Vertex_handle const& candidate) -> bool
   {
     if (triangulation.dimension() != 3) { return false; }
 
@@ -844,9 +884,9 @@ namespace ergodic_moves
   /// @returns The moved triangulation, or nullopt when the topology is not
   /// flippable or the result violates a triangulation or causal-cell invariant
   template <std::uniform_random_bit_generator Generator>
-  [[nodiscard]] inline auto try_62_move(Delaunay const& source_triangulation,
-                                        Vertex_handle const source_candidate,
-                                        Generator&          generator)
+  [[nodiscard]] inline auto detail::try_62_move(
+      Delaunay const&     source_triangulation,
+      Vertex_handle const source_candidate, Generator& generator)
       -> std::optional<Delaunay>
   {
     return detail::try_62_move_impl(source_triangulation, source_candidate,
@@ -887,8 +927,8 @@ namespace ergodic_moves
     // Try a (6,2) move on successive vertices in the sequence
     for (auto const& vertex : vertices)
     {
-      if (!is_62_movable(triangulation, vertex)) { continue; }
-      if (auto moved = try_62_move(triangulation, vertex, generator))
+      if (!detail::is_62_movable(triangulation, vertex)) { continue; }
+      if (auto moved = detail::try_62_move(triangulation, vertex, generator))
       {
         return detail::make_manifold(std::move(*moved), t_manifold);
       }
@@ -907,9 +947,10 @@ namespace ergodic_moves
     auto vertices = foliated_triangulations::collect_vertices<3>(triangulation);
     auto const candidate =
         detail::canonical_random_element(vertices, generator);
-    if (candidate && is_62_movable(triangulation, *candidate))
+    if (candidate && detail::is_62_movable(triangulation, *candidate))
     {
-      if (auto moved = try_62_move(triangulation, *candidate, generator))
+      if (auto moved =
+              detail::try_62_move(triangulation, *candidate, generator))
       {
         return detail::make_manifold(std::move(*moved), t_manifold);
       }
@@ -923,8 +964,8 @@ namespace ergodic_moves
   /// @returns A container of cells incident to the edge or nullopt
   /// @see
   /// https://github.com/CGAL/cgal/blob/8430d04539179f25fb8e716f99e19d28589beeda/TDS_3/include/CGAL/Triangulation_data_structure_3.h#L2094
-  [[nodiscard]] inline auto incident_cells_from_edge(
-      Delaunay_t<3> const& triangulation, Edge_handle const& edge)
+  [[nodiscard]] inline auto detail::incident_cells_from_edge(
+      Delaunay const& triangulation, Edge_handle const& edge)
       -> std::optional<Cell_container>
   {
     return detail::finite_incident_cells(triangulation, edge);
@@ -938,13 +979,13 @@ namespace ergodic_moves
   /// @param triangulation The simplicial manifold
   /// @param t_edge_candidate The edge to check
   /// @returns A container of incident cells if there are exactly 4 or nullopt
-  [[nodiscard]] inline auto find_bistellar_flip_location(
+  [[nodiscard]] inline auto detail::find_bistellar_flip_location(
       Delaunay const& triangulation, Edge_handle const& t_edge_candidate)
       -> std::optional<Cell_container>
   {
     if (!detail::is_well_formed_edge(t_edge_candidate)) { return std::nullopt; }
     auto incident_cells =
-        incident_cells_from_edge(triangulation, t_edge_candidate);
+        detail::incident_cells_from_edge(triangulation, t_edge_candidate);
     if (!incident_cells || incident_cells->size() != 4) { return std::nullopt; }
 
     auto const first_time =
@@ -966,17 +1007,6 @@ namespace ergodic_moves
     }
     return std::nullopt;
   }  // find_bistellar_flip_location()
-
-  /// @brief Return a container of cells incident to an edge.
-  /// @param triangulation The triangulation with the cells.
-  /// @param edge The edge to find the incident cells of.
-  /// @returns A container of cells incident to the edge or nullopt
-  [[nodiscard]] inline auto get_incident_cells(Delaunay const&   triangulation,
-                                               Edge_handle const edge)
-      -> std::optional<Cell_container>
-  {
-    return incident_cells_from_edge(triangulation, edge);
-  }  // get_incident_cells()
 
   namespace detail
   {
@@ -1053,7 +1083,7 @@ namespace ergodic_moves
     Edge_handle const edge{copied_edge_cell, copied_edge_first_index,
                            copied_edge_second_index};
 
-    auto const        incident_cells = get_incident_cells(triangulation, edge);
+    auto const incident_cells = incident_cells_from_edge(triangulation, edge);
     if (!incident_cells || incident_cells->size() != 4 || top == bottom ||
         top == pivot_from_1 || top == pivot_from_2 || bottom == pivot_from_1 ||
         bottom == pivot_from_2 ||
@@ -1135,10 +1165,9 @@ namespace ergodic_moves
   /// @param source_bottom Bottom vertex of the cells being flipped
   /// @returns A flipped triangulation or nullopt
   /// @see [Pachner moves](../REFERENCES.md#pachner-moves)
-  [[nodiscard]] inline auto bistellar_flip(Delaunay const& source_triangulation,
-                                           Edge_handle const   source_edge,
-                                           Vertex_handle const source_top,
-                                           Vertex_handle const source_bottom)
+  [[nodiscard]] inline auto detail::bistellar_flip(
+      Delaunay const& source_triangulation, Edge_handle const source_edge,
+      Vertex_handle const source_top, Vertex_handle const source_bottom)
       -> std::optional<Delaunay>
   {
     return detail::bistellar_flip_impl(source_triangulation, source_edge,
@@ -1147,13 +1176,14 @@ namespace ergodic_moves
   }  // bistellar_flip()
 
   /// @return The center edge of a 4-cell complex
-  [[nodiscard]] inline auto find_pivot_edge(Delaunay const&       triangulation,
-                                            Edge_container const& edges)
+  [[nodiscard]] inline auto detail::find_pivot_edge(
+      Delaunay const& triangulation, Edge_container const& edges)
       -> std::optional<Edge_handle>
   {
     for (auto const& edge : edges)
     {
-      if (auto incident_cells = incident_cells_from_edge(triangulation, edge))
+      if (auto incident_cells =
+              detail::incident_cells_from_edge(triangulation, edge))
       {
         if (incident_cells->size() == 4) { return edge; }
       }
@@ -1164,7 +1194,8 @@ namespace ergodic_moves
   /// @brief Return a container of all vertices in a container of cells.
   /// @param cells The cells to find the vertices of.
   /// @return A container of vertices in the cells
-  [[nodiscard]] inline auto get_vertices(Cell_container const& cells)
+  [[nodiscard]] inline auto detail::get_vertices(Cell_container const& cells)
+      -> Vertex_container
   {
     std::unordered_set<Vertex_handle> vertices;
     auto get_vertices = [&vertices](auto const& cell) {
@@ -1213,7 +1244,7 @@ namespace ergodic_moves
     {
       // Obtain all incident cells
       if (auto const incident_cells =
-              find_bistellar_flip_location(triangulation, edge);
+              detail::find_bistellar_flip_location(triangulation, edge);
           incident_cells)
       {
         // Get edge vertices
@@ -1247,7 +1278,7 @@ namespace ergodic_moves
 
         // Try the bistellar flip
         if (auto flipped_triangulation =
-                bistellar_flip(triangulation, edge, top, bottom);
+                detail::bistellar_flip(triangulation, edge, top, bottom);
             flipped_triangulation.has_value())
         {
           return detail::make_manifold(std::move(*flipped_triangulation),
@@ -1282,7 +1313,7 @@ namespace ergodic_moves
     }
 
     auto const incident_cells =
-        find_bistellar_flip_location(triangulation, *candidate);
+        detail::find_bistellar_flip_location(triangulation, *candidate);
     if (!incident_cells)
     {
       return std::unexpected("Selected (4,4) proposal site is not movable.\n");
@@ -1309,7 +1340,8 @@ namespace ergodic_moves
       }
     }
 
-    if (auto flipped = bistellar_flip(triangulation, *candidate, top, bottom))
+    if (auto flipped =
+            detail::bistellar_flip(triangulation, *candidate, top, bottom))
     {
       return detail::make_manifold(std::move(*flipped), t_manifold);
     }
@@ -1325,10 +1357,9 @@ namespace ergodic_moves
   /// @param t_after The manifold after the move
   /// @param t_move The type of move
   /// @return True if the move correctly changed the triangulation
-  [[nodiscard]] inline auto check_move(Manifold const&                t_before,
-                                       Manifold const&                t_after,
-                                       move_tracker::move_type const& t_move)
-      -> bool
+  [[nodiscard]] inline auto detail::check_move(
+      Manifold const& t_before, Manifold const& t_after,
+      move_tracker::move_type const& t_move) -> bool
   {
     if (!t_after.is_correct() ||
         !detail::same_configuration_value(t_after.initial_radius(),
@@ -1404,6 +1435,6 @@ namespace ergodic_moves
     }
   }  // check_move()
 
-}  // namespace ergodic_moves
+}  // namespace cdt::ergodic_moves
 
 #endif  // CDT_PLUSPLUS_ERGODIC_MOVES_3_HPP

--- a/include/Foliated_triangulation.hpp
+++ b/include/Foliated_triangulation.hpp
@@ -35,57 +35,68 @@
 #include "Triangulation_traits.hpp"
 #include "Utilities.hpp"
 
-template <int dimension>
-using Delaunay_t = typename TriangulationTraits<dimension>::Delaunay;
-
-template <int dimension>
-using Point_t = typename TriangulationTraits<dimension>::Point;
-
-template <int dimension>
-using Causal_vertices_t =
-    std::vector<std::pair<Point_t<dimension>, Int_precision>>;
-
-template <int dimension>
-using Cell_handle_t = typename TriangulationTraits<dimension>::Cell_handle;
-
-template <int dimension>
-using Face_handle_t = typename TriangulationTraits<dimension>::Face_handle;
-
-template <int dimension>
-using Facet_t = typename TriangulationTraits<dimension>::Facet;
-
-template <int dimension>
-using Edge_handle_t = typename TriangulationTraits<dimension>::Edge_handle;
-
-template <int dimension>
-using Vertex_handle_t = typename TriangulationTraits<dimension>::Vertex_handle;
-
-template <int dimension>
-using Spherical_points_generator_t =
-    typename TriangulationTraits<dimension>::Spherical_points_generator;
-
-/// @concept ContainerType
-/// @brief Requires `std::movable`, defined in the standard `<concepts>` header.
-/// @details Right now the real restriction on Containers is that elements must
-/// be swappable in order for std::shuffle to work.
-template <typename C>
-concept ContainerType = std::movable<C>;
-
-/// (n,m) is number of vertices on (lower, higher) timeslice
-enum class Cell_type
+namespace cdt
 {
-  // 3D simplices
-  THREE_ONE    = 31,  // (3,1)
-  TWO_TWO      = 22,  // (2,2)
-  ONE_THREE    = 13,  // (1,3)
-  ACAUSAL      = 99,  // The vertex timevalues differ by > 1 or are all equal
-  UNCLASSIFIED = 0    // An error happened classifying cell
-};
+  template <int dimension>
+  using Delaunay_t = typename detail::TriangulationTraits<dimension>::Delaunay;
 
-namespace foliated_triangulations
+  template <int dimension>
+  using Point_t = typename detail::TriangulationTraits<dimension>::Point;
+
+  template <int dimension>
+  using Causal_vertices_t =
+      std::vector<std::pair<Point_t<dimension>, Int_precision>>;
+
+  template <int dimension>
+  using Cell_handle_t =
+      typename detail::TriangulationTraits<dimension>::Cell_handle;
+
+  template <int dimension>
+  using Face_handle_t =
+      typename detail::TriangulationTraits<dimension>::Face_handle;
+
+  template <int dimension>
+  using Facet_t = typename detail::TriangulationTraits<dimension>::Facet;
+
+  template <int dimension>
+  using Edge_handle_t =
+      typename detail::TriangulationTraits<dimension>::Edge_handle;
+
+  template <int dimension>
+  using Vertex_handle_t =
+      typename detail::TriangulationTraits<dimension>::Vertex_handle;
+
+  template <int dimension>
+  using Spherical_points_generator_t = typename detail::TriangulationTraits<
+      dimension>::Spherical_points_generator;
+
+  /// @concept ContainerType
+  /// @brief Requires `std::movable`, defined in the standard `<concepts>`
+  /// header.
+  /// @details Right now the real restriction on Containers is that elements
+  /// must be swappable in order for std::shuffle to work.
+  namespace detail
+  {
+    template <typename C>
+    concept ContainerType               = std::movable<C>;
+
+    inline int constexpr MAX_FIX_PASSES = 50;
+  }  // namespace detail
+
+  /// (n,m) is number of vertices on (lower, higher) timeslice
+  enum class Cell_type
+  {
+    // 3D simplices
+    THREE_ONE    = 31,  // (3,1)
+    TWO_TWO      = 22,  // (2,2)
+    ONE_THREE    = 13,  // (1,3)
+    ACAUSAL      = 99,  // The vertex timevalues differ by > 1 or are all equal
+    UNCLASSIFIED = 0    // An error happened classifying cell
+  };
+}  // namespace cdt
+
+namespace cdt::foliated_triangulations
 {
-  static int constexpr MAX_FIX_PASSES = 50;
-
   /// @brief Create causal vertices from vertices and timevalues
   /// @tparam dimension Dimensionality of the manifold
   /// @param vertices The vertices of the manifold
@@ -111,8 +122,8 @@ namespace foliated_triangulations
   }
 
   /// @brief Returns a container of all the finite edges in the triangulation
-  /// @details Regardless of the dimensionality of the triangulation, the edges
-  /// are 1-d simplices connecting 0-d vertices.
+  /// @details Regardless of the dimensionality of the triangulation, the
+  /// edges are 1-d simplices connecting 0-d vertices.
   /// @tparam dimension The dimensionality of the triangulation
   /// @param delaunay The triangulation
   /// @returns Container of all the finite edges in the triangulation
@@ -194,7 +205,7 @@ namespace foliated_triangulations
   /// @tparam dimension The dimensionality of the simplices
   /// @param t_vertices The container of vertices
   /// @returns The maximum timevalue in the container
-  template <int dimension, ContainerType Container>
+  template <int dimension, detail::ContainerType Container>
   [[nodiscard]] auto find_max_timevalue(Container&& t_vertices) -> Int_precision
   {
     auto vertices = std::forward<Container>(t_vertices);
@@ -215,7 +226,7 @@ namespace foliated_triangulations
   /// @tparam dimension The dimensionality of the simplices
   /// @param t_vertices The container of vertices
   /// @returns The minimum timevalue in the container
-  template <int dimension, ContainerType Container>
+  template <int dimension, detail::ContainerType Container>
   [[nodiscard]] auto find_min_timevalue(Container&& t_vertices) -> Int_precision
   {
     auto vertices = std::forward<Container>(t_vertices);
@@ -240,7 +251,7 @@ namespace foliated_triangulations
       -> bool
   {
 #ifndef NDEBUG
-    spdlog::debug("{} called.\n", __PRETTY_FUNCTION__);
+    spdlog::debug("{} called.\n", CDT_PRETTY_FUNCTION);
 #endif
     auto const& cell  = t_edge.first;
     auto        time1 = cell->vertex(t_edge.second)->info();
@@ -301,8 +312,9 @@ namespace foliated_triangulations
   [[nodiscard]] auto squared_radius(Vertex_handle_t<dimension> const& t_vertex)
       -> double
   {
-    typename TriangulationTraits<dimension>::squared_distance const r_2;
-    return r_2(t_vertex->point(), TriangulationTraits<dimension>::ORIGIN_POINT);
+    typename detail::TriangulationTraits<dimension>::squared_distance const r_2;
+    return r_2(t_vertex->point(),
+               detail::TriangulationTraits<dimension>::ORIGIN_POINT);
   }  // squared_radius
 
   /// @brief Find the expected timevalue for a vertex
@@ -333,7 +345,8 @@ namespace foliated_triangulations
   /// @param t_vertex The vertex
   /// @param t_initial_radius The initial radius of the radial foliation
   /// @param t_foliation_spacing The spacing between successive leaves
-  /// @returns True if the timevalue of the vertex matches its effective radius
+  /// @returns True if the timevalue of the vertex matches its effective
+  /// radius
   template <int dimension>
   [[nodiscard]] auto is_vertex_timevalue_correct(
       Vertex_handle_t<dimension> const& t_vertex, double const t_initial_radius,
@@ -515,7 +528,7 @@ namespace foliated_triangulations
   [[nodiscard]] auto expected_cell_type(Cell_handle_t<dimension> const& t_cell)
   {
 #ifndef NDEBUG
-    spdlog::debug("{} called.\n", __PRETTY_FUNCTION__);
+    spdlog::debug("{} called.\n", CDT_PRETTY_FUNCTION);
 #endif
     std::array<int, static_cast<std::size_t>(dimension) + 1>
         vertex_timevalues{};
@@ -669,7 +682,7 @@ namespace foliated_triangulations
   /// @tparam dimension The dimensionality of the simplices
   /// @tparam Container The type of container
   /// @param t_cells The cells to write to debug log
-  template <int dimension, ContainerType Container>
+  template <int dimension, detail::ContainerType Container>
   void debug_print_cells(Container&& t_cells)
   {
     for (auto        cells = std::forward<Container>(t_cells);
@@ -727,12 +740,12 @@ namespace foliated_triangulations
   /// @tparam dimension The dimensionality of the simplices
   /// @param t_facets A container of facets
   /// @return Contiguous container with spacelike facets per timeslice
-  template <int dimension, ContainerType Container>
+  template <int dimension, detail::ContainerType Container>
   [[nodiscard]] auto collect_spacelike_facets(Container&& t_facets)
       -> std::vector<std::pair<Int_precision, Facet_t<3>>>
   {
 #ifndef NDEBUG
-    spdlog::debug("{} called.\n", __PRETTY_FUNCTION__);
+    spdlog::debug("{} called.\n", CDT_PRETTY_FUNCTION);
 #endif
     using Volume_entry = std::pair<Int_precision, Facet_t<3>>;
     std::vector<Volume_entry> space_faces;
@@ -787,7 +800,7 @@ namespace foliated_triangulations
   /// @tparam dimension The dimensionality of the simplices
   /// @param t_facets A container of facets
   /// @return Container with spacelike facets per timeslice
-  template <int dimension, ContainerType Container>
+  template <int dimension, detail::ContainerType Container>
   [[nodiscard]] auto volume_per_timeslice(Container&& t_facets)
       -> std::multimap<Int_precision, Facet_t<3>>
   {
@@ -838,7 +851,7 @@ namespace foliated_triangulations
       -> Vertex_handle_t<dimension>
   {
 #ifndef NDEBUG
-    spdlog::debug("{} called.\n", __PRETTY_FUNCTION__);
+    spdlog::debug("{} called.\n", CDT_PRETTY_FUNCTION);
     spdlog::debug("===Invalid Cell===\n");
     std::vector<Cell_handle_t<dimension>> bad_cell{cell};
     debug_print_cells<dimension>(std::span{bad_cell});
@@ -1005,7 +1018,7 @@ namespace foliated_triangulations
       -> Delaunay_t<dimension>
   {
 #ifndef NDEBUG
-    spdlog::debug("{} called.\n", __PRETTY_FUNCTION__);
+    spdlog::debug("{} called.\n", CDT_PRETTY_FUNCTION);
 #endif
     fmt::print("\nGenerating universe ...\n");
 #ifdef CGAL_LINKED_WITH_TBB
@@ -1017,8 +1030,8 @@ namespace foliated_triangulations
                      bounding_box_size, bounding_box_size, bounding_box_size},
         50
     };
-    Delaunay_t<dimension> triangulation =
-        Delaunay_t<dimension>{TriangulationTraits<3>::Kernel{}, &locking_ds};
+    Delaunay_t<dimension> triangulation = Delaunay_t<dimension>{
+        detail::TriangulationTraits<3>::Kernel{}, &locking_ds};
 #else
     Delaunay_t<dimension> triangulation = Delaunay_t<dimension>{};
 #endif
@@ -1030,7 +1043,7 @@ namespace foliated_triangulations
     triangulation.insert(causal_vertices.begin(), causal_vertices.end());
 
     // Fix vertices
-    for (auto passes = 1; passes < MAX_FIX_PASSES + 1; ++passes)
+    for (auto passes = 1; passes < detail::MAX_FIX_PASSES + 1; ++passes)
     {
       if (!fix_vertices<dimension>(triangulation, initial_radius,
                                    foliation_spacing))
@@ -1043,7 +1056,7 @@ namespace foliated_triangulations
     }
 
     // Fix timeslices
-    for (auto passes = 1; passes < MAX_FIX_PASSES + 1; ++passes)
+    for (auto passes = 1; passes < detail::MAX_FIX_PASSES + 1; ++passes)
     {
       if (!fix_timevalues<dimension>(triangulation)) { break; }
 #ifndef NDEBUG
@@ -1052,7 +1065,7 @@ namespace foliated_triangulations
     }
 
     // Fix cells
-    for (auto i = 1; i < MAX_FIX_PASSES + 1; ++i)
+    for (auto i = 1; i < detail::MAX_FIX_PASSES + 1; ++i)
     {
       if (!fix_cells<dimension>(triangulation)) { break; }
 #ifndef NDEBUG
@@ -1076,7 +1089,8 @@ namespace foliated_triangulations
   /// vertex and a simplex type for each cell.
   /// The FoliatedTriangulation class invariant is that the Delaunay
   /// triangulation has validly foliated vertices and cells, and has further
-  /// containers for the various sub-simplicial complexes of the triangulation.
+  /// containers for the various sub-simplicial complexes of the
+  /// triangulation.
   template <>
   class [[nodiscard("This contains data!")]] FoliatedTriangulation<3>  // NOLINT
   {
@@ -1181,8 +1195,9 @@ namespace foliated_triangulations
     }
 
     /// @brief Move constructor
-    /// @details Moves the triangulation and all handle caches directly, without
-    /// first performing the potentially throwing default construction.
+    /// @details Moves the triangulation and all handle caches directly,
+    /// without first performing the potentially throwing default
+    /// construction.
     FoliatedTriangulation(FoliatedTriangulation&& other) noexcept = default;
 
     /// @brief Move assignment operator
@@ -1197,7 +1212,8 @@ namespace foliated_triangulations
     /// @details Note that this function calls swap() from CGAL's
     /// Triangulation_3 base class, which assumes that the first triangulation
     /// is discarded after it is swapped into the second one.
-    /// @param swap_from The value to be swapped from. Assumed to be discarded.
+    /// @param swap_from The value to be swapped from. Assumed to be
+    /// discarded.
     /// @param swap_into The value to be swapped into.
     friend void swap(FoliatedTriangulation& swap_from,
                      FoliatedTriangulation& swap_into) noexcept
@@ -1272,8 +1288,8 @@ namespace foliated_triangulations
     /// @brief Construct from an explicit temporary initialization stream.
     /// @param t_simplices Desired number of simplices
     /// @param t_timeslices Desired number of timeslices
-    /// @param generator Temporary initialization stream whose state is consumed
-    /// during construction
+    /// @param generator Temporary initialization stream whose state is
+    /// consumed during construction
     /// @param t_initial_radius Radius of the first timeslice
     /// @param t_foliation_spacing Radial separation between timeslices
     FoliatedTriangulation(Int_precision const t_simplices,
@@ -1416,8 +1432,8 @@ namespace foliated_triangulations
 
     /// @brief Check the radius of a vertex from the origin with its timevalue
     /// @param t_vertex The vertex to check
-    /// @return True if the effective radial distance squared matches timevalue
-    /// squared
+    /// @return True if the effective radial distance squared matches
+    /// timevalue squared
     [[nodiscard]] auto does_vertex_radius_match_timevalue(
         Vertex_handle_t<3> const t_vertex) const -> bool
     {
@@ -1577,7 +1593,8 @@ namespace foliated_triangulations
 
     /// @brief Classify cells
     /// @param cells The container of simplices to classify
-    /// @return A container of simplices with Cell_type written to cell->info()
+    /// @return A container of simplices with Cell_type written to
+    /// cell->info()
     [[nodiscard]] auto classify_cells(Cell_container const& cells) const
         -> Cell_container
     {
@@ -1634,6 +1651,6 @@ namespace foliated_triangulations
 
   using FoliatedTriangulation_3 = FoliatedTriangulation<3>;
 
-}  // namespace foliated_triangulations
+}  // namespace cdt::foliated_triangulations
 
 #endif  // CDT_PLUSPLUS_FOLIATEDTRIANGULATION_HPP

--- a/include/Geometry.hpp
+++ b/include/Geometry.hpp
@@ -18,94 +18,98 @@
 
 #include "Foliated_triangulation.hpp"
 
-/// Geometry class template
-/// @tparam dimension Dimensionality of geometry
-template <int dimension>
-struct Geometry;
-
-/// 3D Geometry
-template <>
-struct [[nodiscard("This contains data!")]] Geometry<3>
+namespace cdt
 {
-  static_assert(std::is_nothrow_swappable_v<Int_precision>,
-                "Geometry swap requires non-throwing scalar swaps.");
+  /// Geometry class template
+  /// @tparam dimension Dimensionality of geometry
+  template <int dimension>
+  struct Geometry;
 
-  /// @brief Number of 3D simplices
-  Int_precision N3{0};  // NOLINT
-
-  /// @brief Number of (3,1) simplices
-  Int_precision N3_31{0};  // NOLINT
-
-  /// @brief Number of (1,3) simplices
-  Int_precision N3_13{0};  // NOLINT
-
-  /// @brief Number of (3,1) + (1,3) simplices
-  Int_precision N3_31_13{0};  // NOLINT
-
-  /// @brief Number of (2,2) simplices
-  Int_precision N3_22{0};  // NOLINT
-
-  /// @brief Number of 2D faces
-  Int_precision N2{0};  // NOLINT
-
-  /// @brief Number of 1D edges
-  Int_precision N1{0};  // NOLINT
-
-  /// @brief Number of timelike edges
-  Int_precision N1_TL{0};  // NOLINT
-
-  /// @brief Number of spacelike edges
-  Int_precision N1_SL{0};  // NOLINT
-
-  /// @brief Number of vertices
-  Int_precision N0{0};  // NOLINT
-
-  /// @brief Default ctor
-  Geometry() = default;
-
-  /// @brief Constructor with triangulation
-  /// @param triangulation Triangulation for which Geometry is being
-  /// calculated
-  explicit Geometry(
-      foliated_triangulations::FoliatedTriangulation_3 const& triangulation)
-
-      : N3{static_cast<Int_precision>(triangulation.number_of_finite_cells())}
-      , N3_31{static_cast<Int_precision>(
-            triangulation.number_of_three_one_cells())}
-      , N3_13{static_cast<Int_precision>(
-            triangulation.number_of_one_three_cells())}
-      , N3_31_13{N3_31 + N3_13}
-      , N3_22{static_cast<Int_precision>(
-            triangulation.number_of_two_two_cells())}
-      , N2{static_cast<Int_precision>(triangulation.number_of_finite_facets())}
-      , N1{static_cast<Int_precision>(triangulation.number_of_finite_edges())}
-      , N1_TL{triangulation.N1_TL()}
-      , N1_SL{triangulation.N1_SL()}
-      , N0{static_cast<Int_precision>(triangulation.number_of_vertices())}
-
-  {}
-
-  /// @brief Non-member swap function for Geometry
-  /// @details Used for noexcept updates of geometry data structures.
-  /// Usually called from a Manifold swap.
-  /// @param swap_from The value to be swapped from. Assumed to be discarded.
-  /// @param swap_into The value to be swapped into.
-  friend void swap(Geometry& swap_from, Geometry& swap_into) noexcept
+  /// 3D Geometry
+  template <>
+  struct [[nodiscard("This contains data!")]] Geometry<3>
   {
-    using std::swap;
-    swap(swap_from.N3, swap_into.N3);
-    swap(swap_from.N3_31, swap_into.N3_31);
-    swap(swap_from.N3_13, swap_into.N3_13);
-    swap(swap_from.N3_31_13, swap_into.N3_31_13);
-    swap(swap_from.N3_22, swap_into.N3_22);
-    swap(swap_from.N2, swap_into.N2);
-    swap(swap_from.N1, swap_into.N1);
-    swap(swap_from.N1_TL, swap_into.N1_TL);
-    swap(swap_from.N1_SL, swap_into.N1_SL);
-    swap(swap_from.N0, swap_into.N0);
-  }  // swap
-};  // struct Geometry<3>
+    static_assert(std::is_nothrow_swappable_v<Int_precision>,
+                  "Geometry swap requires non-throwing scalar swaps.");
 
-using Geometry_3 = Geometry<3>;
+    /// @brief Number of 3D simplices
+    Int_precision N3{0};  // NOLINT
+
+    /// @brief Number of (3,1) simplices
+    Int_precision N3_31{0};  // NOLINT
+
+    /// @brief Number of (1,3) simplices
+    Int_precision N3_13{0};  // NOLINT
+
+    /// @brief Number of (3,1) + (1,3) simplices
+    Int_precision N3_31_13{0};  // NOLINT
+
+    /// @brief Number of (2,2) simplices
+    Int_precision N3_22{0};  // NOLINT
+
+    /// @brief Number of 2D faces
+    Int_precision N2{0};  // NOLINT
+
+    /// @brief Number of 1D edges
+    Int_precision N1{0};  // NOLINT
+
+    /// @brief Number of timelike edges
+    Int_precision N1_TL{0};  // NOLINT
+
+    /// @brief Number of spacelike edges
+    Int_precision N1_SL{0};  // NOLINT
+
+    /// @brief Number of vertices
+    Int_precision N0{0};  // NOLINT
+
+    /// @brief Default ctor
+    Geometry() = default;
+
+    /// @brief Constructor with triangulation
+    /// @param triangulation Triangulation for which Geometry is being
+    /// calculated
+    explicit Geometry(
+        foliated_triangulations::FoliatedTriangulation_3 const& triangulation)
+
+        : N3{static_cast<Int_precision>(triangulation.number_of_finite_cells())}
+        , N3_31{static_cast<Int_precision>(
+              triangulation.number_of_three_one_cells())}
+        , N3_13{static_cast<Int_precision>(
+              triangulation.number_of_one_three_cells())}
+        , N3_31_13{N3_31 + N3_13}
+        , N3_22{static_cast<Int_precision>(
+              triangulation.number_of_two_two_cells())}
+        , N2{static_cast<Int_precision>(
+              triangulation.number_of_finite_facets())}
+        , N1{static_cast<Int_precision>(triangulation.number_of_finite_edges())}
+        , N1_TL{triangulation.N1_TL()}
+        , N1_SL{triangulation.N1_SL()}
+        , N0{static_cast<Int_precision>(triangulation.number_of_vertices())}
+
+    {}
+
+    /// @brief Non-member swap function for Geometry
+    /// @details Used for noexcept updates of geometry data structures.
+    /// Usually called from a Manifold swap.
+    /// @param swap_from The value to be swapped from. Assumed to be discarded.
+    /// @param swap_into The value to be swapped into.
+    friend void swap(Geometry& swap_from, Geometry& swap_into) noexcept
+    {
+      using std::swap;
+      swap(swap_from.N3, swap_into.N3);
+      swap(swap_from.N3_31, swap_into.N3_31);
+      swap(swap_from.N3_13, swap_into.N3_13);
+      swap(swap_from.N3_31_13, swap_into.N3_31_13);
+      swap(swap_from.N3_22, swap_into.N3_22);
+      swap(swap_from.N2, swap_into.N2);
+      swap(swap_from.N1, swap_into.N1);
+      swap(swap_from.N1_TL, swap_into.N1_TL);
+      swap(swap_from.N1_SL, swap_into.N1_SL);
+      swap(swap_from.N0, swap_into.N0);
+    }  // swap
+  };  // struct Geometry<3>
+
+  using Geometry_3 = Geometry<3>;
+}  // namespace cdt
 
 #endif  // CDT_PLUSPLUS_GEOMETRY_HPP

--- a/include/Manifold.hpp
+++ b/include/Manifold.hpp
@@ -18,7 +18,7 @@
 #include "Geometry.hpp"
 #include "Random.hpp"
 
-namespace manifolds
+namespace cdt::manifolds
 {
   /// @brief Create Causal vertices
   /// @tparam dimension Dimensionality of vertices
@@ -161,7 +161,7 @@ namespace manifolds
     [[nodiscard]] auto updated() const -> Manifold
     {
 #ifndef NDEBUG
-      spdlog::debug("{} called.\n", __PRETTY_FUNCTION__);
+      spdlog::debug("{} called.\n", CDT_PRETTY_FUNCTION);
 #endif
       if (m_triangulation.number_of_vertices() == 0) { return Manifold{}; }
       return Manifold{
@@ -342,6 +342,6 @@ namespace manifolds
 
   using Manifold_3 = Manifold<3>;
 
-}  // namespace manifolds
+}  // namespace cdt::manifolds
 
 #endif  // CDT_PLUSPLUS_MANIFOLD_HPP

--- a/include/Metropolis.hpp
+++ b/include/Metropolis.hpp
@@ -31,555 +31,575 @@
 #include "S3Action.hpp"
 #include "Utilities.hpp"
 
-/// @brief Metropolis-Hastings algorithm strategy
-/// @details The Metropolis-Hastings algorithm is a Markov Chain Monte Carlo
-/// method. For target weight \f$\pi(T)\propto e^{-S(T)}\f$, a proposal from
-/// triangulation \f$T\f$ to \f$T'\f$ is accepted with probability:
-///
-/// \f[\min\left(1, e^{S(T)-S(T')}
-/// \frac{q(T\mid T')}{q(T'\mid T)}\right).\f]
-///
-/// The proposal-ratio construction follows the Hastings transition rule; see
-/// [Metropolis-Hastings
-/// algorithm](../REFERENCES.md#metropolis-hastings-algorithm).
-///
-/// @tparam ManifoldType The type of Manifold on which to apply the algorithm
-template <typename ManifoldType>
-  requires(ManifoldType::dimension == 3)
-class MoveStrategy<Strategies::METROPOLIS, ManifoldType>
+namespace cdt
 {
-  using Counter = move_tracker::MoveTracker<ManifoldType>;
-
-  /// @brief The length of the timelike edges
-  long double m_Alpha{};
-
-  /// @brief \f$K=\frac{1}{8\pi G_{N}}\f$.
-  long double m_K{};
-
-  /// @brief \f$\lambda=\frac{\Lambda}{8\pi G_{N}}\f$ where \f$\Lambda\f$ is
-  /// the cosmological constant
-  long double m_Lambda{};
-
-  /// @brief The number of move passes executed by the algorithm
-  /// @details Each move pass makes a number of attempts equal to the number
-  /// of simplices in the triangulation.
-  Int_precision m_passes{1};
-
-  /// @brief The number of passes before a checkpoint
-  /// @details Each checkpoint writes a file containing the current
-  /// triangulation.
-  Int_precision m_checkpoint{1};
-
-  /// @brief Whether checkpoint and final triangulation files may be written
-  bool m_write_files{true};
-
-  /// @brief The current geometry of the manifold
-  Geometry<ManifoldType::dimension> m_geometry;
-
-  /// @brief Run-owned random engine used for move, site, and acceptance draws
-  cdt::Random m_generator{
-      cdt::Random{}.split(cdt::random_streams::transitions)};
-
-  /// @brief Immutable run provenance, refreshed with state at each output.
-  utilities::Reproducibility_metadata m_reproducibility;
-
-  /// @brief Compact deterministic fingerprint of ordered transition outcomes.
-  std::uint64_t m_transition_trace{14695981039346656037ULL};
-
-  /// @brief Number of transition records incorporated into the fingerprint.
-  std::uint64_t m_transition_count{};
-
-  /// @brief The number of move types and raw sites proposed
-  /// @details This equals accepted moves + rejected moves.
-  Counter m_proposed_moves;
-
-  /// @brief The number of proposals committed as state transitions
-  Counter m_accepted_moves;
-
-  /// @brief The number of explicit self-transitions
-  /// @details Includes inapplicable sites, failed candidate construction, and
-  /// candidates rejected by the Metropolis-Hastings draw.
-  Counter m_rejected_moves;
-
-  /// @brief The number of proposal sites whose construction was attempted
-  /// @details This equals proposed moves.
-  Counter m_attempted_moves;
-
-  /// @brief The number of attempts that produced a valid candidate manifold
-  /// @details A successful candidate may still be rejected by MH.
-  Counter m_succeeded_moves;
-
-  /// @brief The number of inapplicable or invalid candidate constructions
-  Counter m_failed_moves;
-
-  enum class Transition_outcome : std::uint8_t
+  /// @brief Metropolis-Hastings algorithm strategy
+  /// @details The Metropolis-Hastings algorithm is a Markov Chain Monte Carlo
+  /// method. For target weight \f$\pi(T)\propto e^{-S(T)}\f$, a proposal from
+  /// triangulation \f$T\f$ to \f$T'\f$ is accepted with probability:
+  ///
+  /// \f[\min\left(1, e^{S(T)-S(T')}
+  /// \frac{q(T\mid T')}{q(T'\mid T)}\right).\f]
+  ///
+  /// The proposal-ratio construction follows the Hastings transition rule; see
+  /// [Metropolis-Hastings
+  /// algorithm](../REFERENCES.md#metropolis-hastings-algorithm).
+  ///
+  /// @tparam ManifoldType The type of Manifold on which to apply the algorithm
+  template <typename ManifoldType>
+    requires(ManifoldType::dimension == 3)
+  class MoveStrategy<Strategies::METROPOLIS, ManifoldType>
   {
-    CANDIDATE_FAILED,
-    ACCEPTED,
-    REJECTED
-  };
+    using Counter = move_tracker::MoveTracker<ManifoldType>;
 
-  void record_transition(move_tracker::move_type const move,
-                         Transition_outcome const      outcome) noexcept
-  {
-    auto const append = [this](std::uint8_t const value) {
-      m_transition_trace ^= value;
-      m_transition_trace *= 1099511628211ULL;
+    /// @brief The length of the timelike edges
+    long double m_Alpha{};
+
+    /// @brief \f$K=\frac{1}{8\pi G_{N}}\f$.
+    long double m_K{};
+
+    /// @brief \f$\lambda=\frac{\Lambda}{8\pi G_{N}}\f$ where \f$\Lambda\f$ is
+    /// the cosmological constant
+    long double m_Lambda{};
+
+    /// @brief The number of move passes executed by the algorithm
+    /// @details Each move pass makes a number of attempts equal to the number
+    /// of simplices in the triangulation.
+    Int_precision m_passes{1};
+
+    /// @brief The number of passes before a checkpoint
+    /// @details Each checkpoint writes a file containing the current
+    /// triangulation.
+    Int_precision m_checkpoint{1};
+
+    /// @brief Whether checkpoint and final triangulation files may be written
+    bool m_write_files{true};
+
+    /// @brief The current geometry of the manifold
+    Geometry<ManifoldType::dimension> m_geometry;
+
+    /// @brief Run-owned random engine used for move, site, and acceptance draws
+    cdt::Random m_generator{
+        cdt::Random{}.split(cdt::random_streams::transitions)};
+
+    /// @brief Immutable run provenance, refreshed with state at each output.
+    utilities::Reproducibility_metadata m_reproducibility;
+
+    /// @brief Compact deterministic fingerprint of ordered transition outcomes.
+    std::uint64_t m_transition_trace{14695981039346656037ULL};
+
+    /// @brief Number of transition records incorporated into the fingerprint.
+    std::uint64_t m_transition_count{};
+
+    /// @brief The number of move types and raw sites proposed
+    /// @details This equals accepted moves + rejected moves.
+    Counter m_proposed_moves;
+
+    /// @brief The number of proposals committed as state transitions
+    Counter m_accepted_moves;
+
+    /// @brief The number of explicit self-transitions
+    /// @details Includes inapplicable sites, failed candidate construction, and
+    /// candidates rejected by the Metropolis-Hastings draw.
+    Counter m_rejected_moves;
+
+    /// @brief The number of proposal sites whose construction was attempted
+    /// @details This equals proposed moves.
+    Counter m_attempted_moves;
+
+    /// @brief The number of attempts that produced a valid candidate manifold
+    /// @details A successful candidate may still be rejected by MH.
+    Counter m_succeeded_moves;
+
+    /// @brief The number of inapplicable or invalid candidate constructions
+    Counter m_failed_moves;
+
+    enum class Transition_outcome : std::uint8_t
+    {
+      CANDIDATE_FAILED,
+      ACCEPTED,
+      REJECTED
     };
-    append(static_cast<std::uint8_t>(move));
-    append(static_cast<std::uint8_t>(outcome));
-    ++m_transition_count;
-  }
 
- public:
-  /// @brief Construct a default strategy on the named transition stream.
-  MoveStrategy()
-  {
-    m_reproducibility.seed              = m_generator.seed();
-    m_reproducibility.transition_stream = m_generator.stream();
-  }
-
-  /// @brief Metropolis function object constructor
-  /// @details Setup of runtime job parameters.
-  /// @param Alpha \f$\alpha\f$ is the timelike edge length.
-  /// @param K \f$k=\frac{1}{8\pi G_{Newton}}\f$
-  /// @param Lambda \f$\lambda=k*\Lambda\f$ where \f$\Lambda\f$ is the
-  /// Cosmological constant.
-  /// @param passes Number of passes of ergodic moves on triangulation.
-  /// @param checkpoint Print/write output for every n=checkpoint passes.
-  /// @param write_files Whether checkpoints may write triangulation files.
-  [[maybe_unused]] MoveStrategy(long double const Alpha, long double const K,
-                                long double const   Lambda,
-                                Int_precision const passes,
-                                Int_precision const checkpoint,
-                                bool const          write_files = true)
-      : MoveStrategy{Alpha,
-                     K,
-                     Lambda,
-                     passes,
-                     checkpoint,
-                     write_files,
-                     cdt::Random{}.split(cdt::random_streams::transitions)}
-  {}
-
-  /// @brief Construct a run from an already selected PCG stream.
-  /// @details Seed, transition-stream, action, and cadence provenance are
-  /// derived from the actual constructor arguments. Caller metadata supplies
-  /// initialization and requested-state context only.
-  [[maybe_unused]] MoveStrategy(
-      long double const Alpha, long double const K, long double const Lambda,
-      Int_precision const passes, Int_precision const checkpoint,
-      bool const write_files, cdt::Random random,
-      std::optional<utilities::Reproducibility_metadata> reproducibility =
-          std::nullopt)
-      : m_passes(passes)
-      , m_checkpoint{checkpoint}
-      , m_write_files{write_files}
-      , m_generator{std::move(random)}
-      , m_reproducibility{
-            reproducibility.value_or(utilities::Reproducibility_metadata{
-                .seed                = m_generator.seed(),
-                .alpha               = Alpha,
-                .k                   = K,
-                .lambda              = Lambda,
-                .configured_passes   = passes,
-                .checkpoint_interval = checkpoint})}
-  {
-    auto const parameters =
-        s3_action::make_physical_parameters(Alpha, K, Lambda);
-    m_Alpha                               = parameters.alpha;
-    m_K                                   = parameters.k;
-    m_Lambda                              = parameters.lambda;
-    m_reproducibility.seed                = m_generator.seed();
-    m_reproducibility.transition_stream   = m_generator.stream();
-    m_reproducibility.alpha               = m_Alpha;
-    m_reproducibility.k                   = m_K;
-    m_reproducibility.lambda              = m_Lambda;
-    m_reproducibility.configured_passes   = m_passes;
-    m_reproducibility.checkpoint_interval = m_checkpoint;
-    if (m_passes <= 0)
+    void record_transition(move_tracker::move_type const move,
+                           Transition_outcome const      outcome) noexcept
     {
-      throw std::invalid_argument{"Metropolis passes must be positive"};
+      auto const append = [this](std::uint8_t const value) {
+        m_transition_trace ^= value;
+        m_transition_trace *= 1099511628211ULL;
+      };
+      append(static_cast<std::uint8_t>(move));
+      append(static_cast<std::uint8_t>(outcome));
+      ++m_transition_count;
     }
-    if (m_checkpoint <= 0)
+
+   public:
+    /// @brief Construct a default strategy on the named transition stream.
+    MoveStrategy()
     {
-      throw std::invalid_argument{
-          "Metropolis checkpoint interval must be positive"};
+      m_reproducibility.seed              = m_generator.seed();
+      m_reproducibility.transition_stream = m_generator.stream();
     }
+
+    /// @brief Metropolis function object constructor
+    /// @details Setup of runtime job parameters.
+    /// @param Alpha \f$\alpha\f$ is the timelike edge length.
+    /// @param K \f$k=\frac{1}{8\pi G_{Newton}}\f$
+    /// @param Lambda \f$\lambda=k*\Lambda\f$ where \f$\Lambda\f$ is the
+    /// Cosmological constant.
+    /// @param passes Number of passes of ergodic moves on triangulation.
+    /// @param checkpoint Print/write output for every n=checkpoint passes.
+    /// @param write_files Whether checkpoints may write triangulation files.
+    [[maybe_unused]] MoveStrategy(long double const Alpha, long double const K,
+                                  long double const   Lambda,
+                                  Int_precision const passes,
+                                  Int_precision const checkpoint,
+                                  bool const          write_files = true)
+        : MoveStrategy{Alpha,
+                       K,
+                       Lambda,
+                       passes,
+                       checkpoint,
+                       write_files,
+                       cdt::Random{}.split(cdt::random_streams::transitions)}
+    {}
+
+    /// @brief Construct a run from an already selected PCG stream.
+    /// @details Seed, transition-stream, action, and cadence provenance are
+    /// derived from the actual constructor arguments. Caller metadata supplies
+    /// initialization and requested-state context only.
+    [[maybe_unused]] MoveStrategy(
+        long double const Alpha, long double const K, long double const Lambda,
+        Int_precision const passes, Int_precision const checkpoint,
+        bool const write_files, cdt::Random random,
+        std::optional<utilities::Reproducibility_metadata> reproducibility =
+            std::nullopt)
+        : m_passes(passes)
+        , m_checkpoint{checkpoint}
+        , m_write_files{write_files}
+        , m_generator{std::move(random)}
+        , m_reproducibility{
+              reproducibility.value_or(utilities::Reproducibility_metadata{
+                  .seed                = m_generator.seed(),
+                  .alpha               = Alpha,
+                  .k                   = K,
+                  .lambda              = Lambda,
+                  .configured_passes   = passes,
+                  .checkpoint_interval = checkpoint})}
+    {
+      auto const parameters =
+          s3_action::make_physical_parameters(Alpha, K, Lambda);
+      m_Alpha                               = parameters.alpha;
+      m_K                                   = parameters.k;
+      m_Lambda                              = parameters.lambda;
+      m_reproducibility.seed                = m_generator.seed();
+      m_reproducibility.transition_stream   = m_generator.stream();
+      m_reproducibility.alpha               = m_Alpha;
+      m_reproducibility.k                   = m_K;
+      m_reproducibility.lambda              = m_Lambda;
+      m_reproducibility.configured_passes   = m_passes;
+      m_reproducibility.checkpoint_interval = m_checkpoint;
+      if (m_passes <= 0)
+      {
+        throw std::invalid_argument{"Metropolis passes must be positive"};
+      }
+      if (m_checkpoint <= 0)
+      {
+        throw std::invalid_argument{
+            "Metropolis checkpoint interval must be positive"};
+      }
 #ifndef NDEBUG
-    spdlog::debug("{} called.\n", __PRETTY_FUNCTION__);
+      spdlog::debug("{} called.\n", CDT_PRETTY_FUNCTION);
 #endif
-  }
-
-  /// @brief Construct a replayable run with an explicit RNG seed.
-  MoveStrategy(long double const Alpha, long double const K,
-               long double const Lambda, Int_precision const passes,
-               Int_precision const checkpoint, bool const write_files,
-               std::uint64_t const seed)
-      : MoveStrategy{
-            Alpha,
-            K,
-            Lambda,
-            passes,
-            checkpoint,
-            write_files,
-            cdt::Random{seed, cdt::random_streams::transitions}
-  }
-  {}
-
-  /// @returns The length of the timelike edge
-  [[nodiscard]] auto Alpha() const noexcept { return m_Alpha; }
-
-  /// @returns The normalized Newton's constant
-  [[nodiscard]] auto K() const noexcept { return m_K; }
-
-  /// @returns The normalized Cosmological constant
-  [[nodiscard]] auto Lambda() const noexcept { return m_Lambda; }
-
-  /// @returns The number of passes to make
-  [[nodiscard]] auto passes() const noexcept { return m_passes; }
-
-  /// @returns The number of passes before writing a checkpoint file
-  [[nodiscard]] auto checkpoint() const noexcept { return m_checkpoint; }
-
-  /// @returns Whether the strategy writes checkpoint triangulation files
-  [[nodiscard]] auto writes_files() const noexcept { return m_write_files; }
-
-  /// @returns The effective root seed used for this run.
-  [[nodiscard]] auto seed() const noexcept { return m_generator.seed(); }
-
-  /// @returns The PCG stream selector used for transitions.
-  [[nodiscard]] auto stream() const noexcept { return m_generator.stream(); }
-
-  /// @returns FNV-1a fingerprint of the ordered move/outcome transition trace.
-  [[nodiscard]] auto transition_trace() const noexcept
-  { return m_transition_trace; }
-
-  /// @returns Number of transitions represented by transition_trace().
-  [[nodiscard]] auto transition_count() const noexcept
-  { return m_transition_count; }
-
-  /// @brief Materialize output provenance for the supplied canonical state.
-  [[nodiscard]] auto reproducibility_metadata(
-      ManifoldType const& manifold, utilities::Artifact_kind const artifact,
-      Int_precision const completed_passes) const
-      -> utilities::Reproducibility_metadata
-  {
-    auto metadata             = m_reproducibility;
-    metadata.artifact         = artifact;
-    metadata.completed_passes = completed_passes;
-    metadata.transition_trace = m_transition_trace;
-    metadata.transition_count = m_transition_count;
-    utilities::update_reproducibility_state(metadata, manifold);
-    if (metadata.desired_simplices == 0)
-    {
-      metadata.desired_simplices = manifold.N3();
-    }
-    if (metadata.desired_timeslices == 0)
-    {
-      metadata.desired_timeslices = manifold.max_time();
-    }
-    return metadata;
-  }
-
-  /// @returns The container of trial moves
-  auto get_proposed() const { return m_proposed_moves; }
-
-  /// @returns The container of accepted moves
-  auto get_accepted() const { return m_accepted_moves; }
-
-  /// @returns The container of rejected moves
-  auto get_rejected() const { return m_rejected_moves; }
-
-  /// @returns The container of attempted moves
-  auto get_attempted() const { return m_attempted_moves; }
-
-  /// @returns The container of successful moves
-  auto get_succeeded() const { return m_succeeded_moves; }
-
-  /// @returns The container of failed moves
-  auto get_failed() const { return m_failed_moves; }
-
-  /// @returns The geometry used by the most recent acceptance decision
-  [[nodiscard]] auto get_geometry() const noexcept
-      -> Geometry<ManifoldType::dimension> const&
-  { return m_geometry; }
-
-  /// @returns The inverse Pachner move
-  [[nodiscard]] static auto constexpr reverse_move(
-      move_tracker::move_type const move) noexcept -> move_tracker::move_type
-  {
-    using enum move_tracker::move_type;
-    switch (move)
-    {
-      case TWO_THREE: return THREE_TWO;
-      case THREE_TWO: return TWO_THREE;
-      case TWO_SIX: return SIX_TWO;
-      case SIX_TWO: return TWO_SIX;
-      case FOUR_FOUR: return FOUR_FOUR;
-    }
-    return FOUR_FOUR;
-  }
-
-  /// @returns The number of raw sites from which a move type is proposed
-  [[nodiscard]] static auto constexpr proposal_site_count(
-      Geometry<ManifoldType::dimension> const& geometry,
-      move_tracker::move_type const            move) noexcept -> Int_precision
-  {
-    using enum move_tracker::move_type;
-    switch (move)
-    {
-      case TWO_THREE: return geometry.N3_22;
-      case THREE_TWO: return geometry.N1_TL;
-      case TWO_SIX: return geometry.N3_13;
-      case SIX_TWO: return geometry.N0;
-      case FOUR_FOUR: return geometry.N1_SL;
-    }
-    return 0;
-  }
-
-  /// @returns The probability of selecting a particular raw proposal site
-  /// @details Move types are uniform. A raw site is then uniform within its
-  /// type-specific domain. Inapplicable sites remain explicit self-transitions.
-  [[nodiscard]] static auto proposal_probability(
-      Geometry<ManifoldType::dimension> const& geometry,
-      move_tracker::move_type const            move) -> mpfr_values::Value
-  {
-    auto const sites = proposal_site_count(geometry, move);
-    if (sites <= 0) { return mpfr_values::zero(); }
-    auto const move_count =
-        mpfr_values::from_integer(move_tracker::NUMBER_OF_3D_MOVES);
-    auto const site_count  = mpfr_values::from_integer(sites);
-    auto const denominator = mpfr_values::multiply(move_count, site_count);
-    return mpfr_values::divide(mpfr_values::from_integer(1), denominator);
-  }
-
-  /// @brief Calculate the Hastings reverse-to-forward proposal ratio
-  /// @see [Metropolis-Hastings
-  /// algorithm](../REFERENCES.md#metropolis-hastings-algorithm)
-  [[nodiscard]] static auto CalculateA1(
-      Geometry<ManifoldType::dimension> const& current,
-      Geometry<ManifoldType::dimension> const& proposed,
-      move_tracker::move_type const            move) -> mpfr_values::Value
-  {
-    auto const forward = proposal_probability(current, move);
-    auto const reverse = proposal_probability(proposed, reverse_move(move));
-    if (mpfr_zero_p(forward.fr()) != 0 || mpfr_zero_p(reverse.fr()) != 0)
-    {
-      throw std::logic_error(
-          "A successful reversible proposal must have nonzero forward and reverse probabilities.");
-    }
-    return mpfr_values::divide(reverse, forward);
-  }
-
-  /// @brief Calculate the action factor \f$e^{S(T)-S(T')}\f$
-  /// @see [Three-dimensional CDT
-  /// action](../REFERENCES.md#three-dimensional-cdt-2001)
-  [[nodiscard]] auto CalculateA2(
-      Geometry<ManifoldType::dimension> const& current,
-      Geometry<ManifoldType::dimension> const& proposed) const
-      -> mpfr_values::Value
-  {
-    auto const current_action = S3_bulk_action(
-        current.N1_TL, current.N3_31_13, current.N3_22, m_Alpha, m_K, m_Lambda);
-    auto const proposed_action =
-        S3_bulk_action(proposed.N1_TL, proposed.N3_31_13, proposed.N3_22,
-                       m_Alpha, m_K, m_Lambda);
-    return mpfr_values::exponential(
-        mpfr_values::subtract(current_action, proposed_action));
-  }
-
-  /// @returns \f$\min(1, q(T|T')/q(T'|T)e^{S(T)-S(T')})\f$
-  [[nodiscard]] auto acceptance_probability(
-      Geometry<ManifoldType::dimension> const& current,
-      Geometry<ManifoldType::dimension> const& proposed,
-      move_tracker::move_type const            move) const -> mpfr_values::Value
-  {
-    auto const ratio = mpfr_values::multiply(
-        CalculateA1(current, proposed, move), CalculateA2(current, proposed));
-    auto const one = mpfr_values::from_integer(1);
-    return mpfr_cmp(ratio.fr(), one.fr()) < 0 ? ratio : one;
-  }
-
- private:
-  [[nodiscard]] auto propose_candidate(ManifoldType const&           current,
-                                       move_tracker::move_type const move)
-      -> std::expected<ManifoldType, std::string>
-  {
-    using enum move_tracker::move_type;
-    switch (move)
-    {
-      case TWO_THREE:
-        return ergodic_moves::propose_23_move(current, m_generator);
-      case THREE_TWO:
-        return ergodic_moves::propose_32_move(current, m_generator);
-      case TWO_SIX: return ergodic_moves::propose_26_move(current, m_generator);
-      case SIX_TWO: return ergodic_moves::propose_62_move(current, m_generator);
-      case FOUR_FOUR:
-        return ergodic_moves::propose_44_move(current, m_generator);
-    }
-    return std::unexpected("Unknown 3D Pachner move.\n");
-  }
-
- public:
-  /// @brief Attempt and immediately resolve one Markov transition
-  /// @param current Canonical state, updated only after a successful MH accept
-  /// @param move Uniformly selected move type
-  /// @param trial_value Uniform draw in [0,1], injectable for focused tests
-  /// @returns True only when a valid candidate is accepted and committed
-  auto attempt_transition(ManifoldType&                 current,
-                          move_tracker::move_type const move,
-                          long double const             trial_value) -> bool
-  {
-    if (!std::isfinite(trial_value) || trial_value < 0.0L || trial_value > 1.0L)
-    {
-      throw std::invalid_argument("MH trial value must lie in [0, 1].");
     }
 
-    m_geometry = current.get_geometry();
-    ++m_proposed_moves[move];
-    ++m_attempted_moves[move];
+    /// @brief Construct a replayable run with an explicit RNG seed.
+    MoveStrategy(long double const Alpha, long double const K,
+                 long double const Lambda, Int_precision const passes,
+                 Int_precision const checkpoint, bool const write_files,
+                 std::uint64_t const seed)
+        : MoveStrategy{
+              Alpha,
+              K,
+              Lambda,
+              passes,
+              checkpoint,
+              write_files,
+              cdt::Random{seed, cdt::random_streams::transitions}
+    }
+    {}
 
-    auto candidate = propose_candidate(current, move);
-    if (!candidate || !ergodic_moves::check_move(current, *candidate, move))
+    /// @returns The length of the timelike edge
+    [[nodiscard]] auto Alpha() const noexcept { return m_Alpha; }
+
+    /// @returns The normalized Newton's constant
+    [[nodiscard]] auto K() const noexcept { return m_K; }
+
+    /// @returns The normalized Cosmological constant
+    [[nodiscard]] auto Lambda() const noexcept { return m_Lambda; }
+
+    /// @returns The number of passes to make
+    [[nodiscard]] auto passes() const noexcept { return m_passes; }
+
+    /// @returns The number of passes before writing a checkpoint file
+    [[nodiscard]] auto checkpoint() const noexcept { return m_checkpoint; }
+
+    /// @returns Whether the strategy writes checkpoint triangulation files
+    [[nodiscard]] auto writes_files() const noexcept { return m_write_files; }
+
+    /// @returns The effective root seed used for this run.
+    [[nodiscard]] auto seed() const noexcept { return m_generator.seed(); }
+
+    /// @returns The PCG stream selector used for transitions.
+    [[nodiscard]] auto stream() const noexcept { return m_generator.stream(); }
+
+    /// @returns FNV-1a fingerprint of the ordered move/outcome transition
+    /// trace.
+    [[nodiscard]] auto transition_trace() const noexcept
+    { return m_transition_trace; }
+
+    /// @returns Number of transitions represented by transition_trace().
+    [[nodiscard]] auto transition_count() const noexcept
+    { return m_transition_count; }
+
+    /// @brief Materialize output provenance for the supplied canonical state.
+    [[nodiscard]] auto reproducibility_metadata(
+        ManifoldType const& manifold, utilities::Artifact_kind const artifact,
+        Int_precision const completed_passes) const
+        -> utilities::Reproducibility_metadata
     {
-      ++m_failed_moves[move];
+      auto metadata             = m_reproducibility;
+      metadata.artifact         = artifact;
+      metadata.completed_passes = completed_passes;
+      metadata.transition_trace = m_transition_trace;
+      metadata.transition_count = m_transition_count;
+      utilities::update_reproducibility_state(metadata, manifold);
+      if (metadata.desired_simplices == 0)
+      {
+        metadata.desired_simplices = manifold.N3();
+      }
+      if (metadata.desired_timeslices == 0)
+      {
+        metadata.desired_timeslices = manifold.max_time();
+      }
+      return metadata;
+    }
+
+    /// @returns The container of trial moves
+    auto get_proposed() const { return m_proposed_moves; }
+
+    /// @returns The container of accepted moves
+    auto get_accepted() const { return m_accepted_moves; }
+
+    /// @returns The container of rejected moves
+    auto get_rejected() const { return m_rejected_moves; }
+
+    /// @returns The container of attempted moves
+    auto get_attempted() const { return m_attempted_moves; }
+
+    /// @returns The container of successful moves
+    auto get_succeeded() const { return m_succeeded_moves; }
+
+    /// @returns The container of failed moves
+    auto get_failed() const { return m_failed_moves; }
+
+    /// @returns The geometry used by the most recent acceptance decision
+    [[nodiscard]] auto get_geometry() const noexcept
+        -> Geometry<ManifoldType::dimension> const&
+    { return m_geometry; }
+
+    /// @returns The inverse Pachner move
+    [[nodiscard]] static auto constexpr reverse_move(
+        move_tracker::move_type const move) noexcept -> move_tracker::move_type
+    {
+      using enum move_tracker::move_type;
+      switch (move)
+      {
+        case TWO_THREE: return THREE_TWO;
+        case THREE_TWO: return TWO_THREE;
+        case TWO_SIX: return SIX_TWO;
+        case SIX_TWO: return TWO_SIX;
+        case FOUR_FOUR: return FOUR_FOUR;
+      }
+      return FOUR_FOUR;
+    }
+
+    /// @returns The number of raw sites from which a move type is proposed
+    [[nodiscard]] static auto constexpr proposal_site_count(
+        Geometry<ManifoldType::dimension> const& geometry,
+        move_tracker::move_type const            move) noexcept -> Int_precision
+    {
+      using enum move_tracker::move_type;
+      switch (move)
+      {
+        case TWO_THREE: return geometry.N3_22;
+        case THREE_TWO: return geometry.N1_TL;
+        case TWO_SIX: return geometry.N3_13;
+        case SIX_TWO: return geometry.N0;
+        case FOUR_FOUR: return geometry.N1_SL;
+      }
+      return 0;
+    }
+
+    /// @returns The probability of selecting a particular raw proposal site
+    /// @details Move types are uniform. A raw site is then uniform within its
+    /// type-specific domain. Inapplicable sites remain explicit
+    /// self-transitions.
+    [[nodiscard]] static auto proposal_probability(
+        Geometry<ManifoldType::dimension> const& geometry,
+        move_tracker::move_type const            move) -> mpfr_values::Value
+    {
+      auto const sites = proposal_site_count(geometry, move);
+      if (sites <= 0) { return mpfr_values::zero(); }
+      auto const move_count =
+          mpfr_values::from_integer(move_tracker::NUMBER_OF_3D_MOVES);
+      auto const site_count  = mpfr_values::from_integer(sites);
+      auto const denominator = mpfr_values::multiply(move_count, site_count);
+      return mpfr_values::divide(mpfr_values::from_integer(1), denominator);
+    }
+
+    /// @brief Calculate the Hastings reverse-to-forward proposal ratio
+    /// @see [Metropolis-Hastings
+    /// algorithm](../REFERENCES.md#metropolis-hastings-algorithm)
+    [[nodiscard]] static auto CalculateA1(
+        Geometry<ManifoldType::dimension> const& current,
+        Geometry<ManifoldType::dimension> const& proposed,
+        move_tracker::move_type const            move) -> mpfr_values::Value
+    {
+      auto const forward = proposal_probability(current, move);
+      auto const reverse = proposal_probability(proposed, reverse_move(move));
+      if (mpfr_zero_p(forward.fr()) != 0 || mpfr_zero_p(reverse.fr()) != 0)
+      {
+        throw std::logic_error(
+            "A successful reversible proposal must have nonzero forward and reverse probabilities.");
+      }
+      return mpfr_values::divide(reverse, forward);
+    }
+
+    /// @brief Calculate the action factor \f$e^{S(T)-S(T')}\f$
+    /// @see [Three-dimensional CDT
+    /// action](../REFERENCES.md#three-dimensional-cdt-2001)
+    [[nodiscard]] auto CalculateA2(
+        Geometry<ManifoldType::dimension> const& current,
+        Geometry<ManifoldType::dimension> const& proposed) const
+        -> mpfr_values::Value
+    {
+      auto const current_action =
+          s3_action::S3_bulk_action(current.N1_TL, current.N3_31_13,
+                                    current.N3_22, m_Alpha, m_K, m_Lambda);
+      auto const proposed_action =
+          s3_action::S3_bulk_action(proposed.N1_TL, proposed.N3_31_13,
+                                    proposed.N3_22, m_Alpha, m_K, m_Lambda);
+      return mpfr_values::exponential(
+          mpfr_values::subtract(current_action, proposed_action));
+    }
+
+    /// @returns \f$\min(1, q(T|T')/q(T'|T)e^{S(T)-S(T')})\f$
+    [[nodiscard]] auto acceptance_probability(
+        Geometry<ManifoldType::dimension> const& current,
+        Geometry<ManifoldType::dimension> const& proposed,
+        move_tracker::move_type const move) const -> mpfr_values::Value
+    {
+      auto const ratio = mpfr_values::multiply(
+          CalculateA1(current, proposed, move), CalculateA2(current, proposed));
+      auto const one = mpfr_values::from_integer(1);
+      return mpfr_cmp(ratio.fr(), one.fr()) < 0 ? ratio : one;
+    }
+
+   private:
+    [[nodiscard]] auto propose_candidate(ManifoldType const&           current,
+                                         move_tracker::move_type const move)
+        -> std::expected<ManifoldType, std::string>
+    {
+      using enum move_tracker::move_type;
+      switch (move)
+      {
+        case TWO_THREE:
+          return ergodic_moves::propose_23_move(current, m_generator);
+        case THREE_TWO:
+          return ergodic_moves::propose_32_move(current, m_generator);
+        case TWO_SIX:
+          return ergodic_moves::propose_26_move(current, m_generator);
+        case SIX_TWO:
+          return ergodic_moves::propose_62_move(current, m_generator);
+        case FOUR_FOUR:
+          return ergodic_moves::propose_44_move(current, m_generator);
+      }
+      return std::unexpected("Unknown 3D Pachner move.\n");
+    }
+
+   public:
+    /// @brief Attempt and immediately resolve one Markov transition
+    /// @param current Canonical state, updated only after a successful MH
+    /// accept
+    /// @param move Uniformly selected move type
+    /// @param trial_value Uniform draw in [0,1], injectable for focused tests
+    /// @returns True only when a valid candidate is accepted and committed
+    auto attempt_transition(ManifoldType&                 current,
+                            move_tracker::move_type const move,
+                            long double const             trial_value) -> bool
+    {
+      if (!std::isfinite(trial_value) || trial_value < 0.0L ||
+          trial_value > 1.0L)
+      {
+        throw std::invalid_argument("MH trial value must lie in [0, 1].");
+      }
+
+      m_geometry = current.get_geometry();
+      ++m_proposed_moves[move];
+      ++m_attempted_moves[move];
+
+      auto candidate = propose_candidate(current, move);
+      if (!candidate ||
+          !ergodic_moves::detail::check_move(current, *candidate, move))
+      {
+        ++m_failed_moves[move];
+        ++m_rejected_moves[move];
+        record_transition(move, Transition_outcome::CANDIDATE_FAILED);
+        return false;
+      }
+
+      ++m_succeeded_moves[move];
+      auto const probability =
+          acceptance_probability(m_geometry, candidate->get_geometry(), move);
+      if (mpfr_cmp_ld(probability.fr(), trial_value) >= 0)
+      {
+        swap(*candidate, current);
+        m_geometry = current.get_geometry();
+        ++m_accepted_moves[move];
+        record_transition(move, Transition_outcome::ACCEPTED);
+        return true;
+      }
+
       ++m_rejected_moves[move];
-      record_transition(move, Transition_outcome::CANDIDATE_FAILED);
+      record_transition(move, Transition_outcome::REJECTED);
       return false;
     }
 
-    ++m_succeeded_moves[move];
-    auto const probability =
-        acceptance_probability(m_geometry, candidate->get_geometry(), move);
-    if (mpfr_cmp_ld(probability.fr(), trial_value) >= 0)
+    /// @brief Initialize the cached action geometry from the canonical manifold
+    void initialize(ManifoldType const& manifold)
+    { m_geometry = manifold.get_geometry(); }
+
+    /// @brief Run sequential Metropolis-Hastings passes on a manifold
+    auto operator()(ManifoldType const& t_manifold) -> ManifoldType
     {
-      swap(*candidate, current);
-      m_geometry = current.get_geometry();
-      ++m_accepted_moves[move];
-      record_transition(move, Transition_outcome::ACCEPTED);
-      return true;
-    }
-
-    ++m_rejected_moves[move];
-    record_transition(move, Transition_outcome::REJECTED);
-    return false;
-  }
-
-  /// @brief Initialize the cached action geometry from the canonical manifold
-  void initialize(ManifoldType const& manifold)
-  { m_geometry = manifold.get_geometry(); }
-
-  /// @brief Run sequential Metropolis-Hastings passes on a manifold
-  auto operator()(ManifoldType const& t_manifold) -> ManifoldType
-  {
 #ifndef NDEBUG
-    spdlog::debug("{} called.\n", __PRETTY_FUNCTION__);
+      spdlog::debug("{} called.\n", CDT_PRETTY_FUNCTION);
 #endif
 
-    fmt::print(
-        "Starting Metropolis-Hastings algorithm in {}+1 dimensions ...\n",
-        ManifoldType::dimension - 1);
-    fmt::print("Effective random seed: {} (stream {}).\n", m_generator.seed(),
-               m_generator.stream());
+      fmt::print(
+          "Starting Metropolis-Hastings algorithm in {}+1 dimensions ...\n",
+          ManifoldType::dimension - 1);
+      fmt::print("Effective random seed: {} (stream {}).\n", m_generator.seed(),
+                 m_generator.stream());
 
-    m_proposed_moves.reset();
-    m_accepted_moves.reset();
-    m_rejected_moves.reset();
-    m_attempted_moves.reset();
-    m_succeeded_moves.reset();
-    m_failed_moves.reset();
-    m_transition_trace = 14695981039346656037ULL;
-    m_transition_count = 0;
+      m_proposed_moves.reset();
+      m_accepted_moves.reset();
+      m_rejected_moves.reset();
+      m_attempted_moves.reset();
+      m_succeeded_moves.reset();
+      m_failed_moves.reset();
+      m_transition_trace = 14695981039346656037ULL;
+      m_transition_count = 0;
 
-    auto current       = t_manifold;
-    initialize(current);
-    std::uniform_real_distribution<long double> acceptance_draw{0.0L, 1.0L};
+      auto current       = t_manifold;
+      initialize(current);
+      std::uniform_real_distribution<long double> acceptance_draw{0.0L, 1.0L};
 
-    fmt::print("Making random moves ...\n");
-    for (auto pass_number = 1; pass_number <= m_passes; ++pass_number)
-    {
-      fmt::print("=== Pass {} ===\n", pass_number);
-      auto const attempts_this_pass = current.N3();
-      for (auto move_attempt = 0; move_attempt < attempts_this_pass;
-           ++move_attempt)
+      fmt::print("Making random moves ...\n");
+      for (auto pass_number = 1; pass_number <= m_passes; ++pass_number)
       {
-        auto const move = move_tracker::generate_random_move_3(m_generator);
-        static_cast<void>(
-            attempt_transition(current, move, acceptance_draw(m_generator)));
-      }
-
-      if (pass_number % m_checkpoint == 0)
-      {
-        print_results();
-        if (m_write_files)
+        fmt::print("=== Pass {} ===\n", pass_number);
+        auto const attempts_this_pass = current.N3();
+        for (auto move_attempt = 0; move_attempt < attempts_this_pass;
+             ++move_attempt)
         {
-          fmt::print("Writing to file.\n");
-          utilities::write_file(
-              current,
-              reproducibility_metadata(
-                  current, utilities::Artifact_kind::CHECKPOINT, pass_number));
+          auto const move = move_tracker::generate_random_move_3(m_generator);
+          static_cast<void>(
+              attempt_transition(current, move, acceptance_draw(m_generator)));
+        }
+
+        if (pass_number % m_checkpoint == 0)
+        {
+          print_results();
+          if (m_write_files)
+          {
+            fmt::print("Writing to file.\n");
+            utilities::write_file(
+                current, reproducibility_metadata(
+                             current, utilities::Artifact_kind::CHECKPOINT,
+                             pass_number));
+          }
         }
       }
-    }
 
-    fmt::print("=== Run results ===\n");
-    print_results();
-    return current;
-  }  // operator()
+      fmt::print("=== Run results ===\n");
+      print_results();
+      return current;
+    }  // operator()
 
-  /// @brief Display results of run
-  void print_results()
-  {
-    fmt::print("=== Move Results ===\n");
-    fmt::print(
-        "There were {} proposed moves with {} accepted moves and {} rejected "
-        "moves.\n",
-        m_proposed_moves.total(), m_accepted_moves.total(),
-        m_rejected_moves.total());
-    fmt::print(
-        "There were {} candidate construction attempts with {} successful "
-        "candidates and {} failed candidates.\n",
-        m_attempted_moves.total(), m_succeeded_moves.total(),
-        m_failed_moves.total());
-    fmt::print(
-        "(2,3) moves: {} proposed ({} accepted and {} rejected); candidate "
-        "construction: {} attempted ({} succeeded and {} failed).\n",
-        m_proposed_moves.two_three_moves(), m_accepted_moves.two_three_moves(),
-        m_rejected_moves.two_three_moves(), m_attempted_moves.two_three_moves(),
-        m_succeeded_moves.two_three_moves(), m_failed_moves.two_three_moves());
+    /// @brief Display results of run
+    void print_results()
+    {
+      fmt::print("=== Move Results ===\n");
+      fmt::print(
+          "There were {} proposed moves with {} accepted moves and {} rejected "
+          "moves.\n",
+          m_proposed_moves.total(), m_accepted_moves.total(),
+          m_rejected_moves.total());
+      fmt::print(
+          "There were {} candidate construction attempts with {} successful "
+          "candidates and {} failed candidates.\n",
+          m_attempted_moves.total(), m_succeeded_moves.total(),
+          m_failed_moves.total());
+      fmt::print(
+          "(2,3) moves: {} proposed ({} accepted and {} rejected); candidate "
+          "construction: {} attempted ({} succeeded and {} failed).\n",
+          m_proposed_moves.two_three_moves(),
+          m_accepted_moves.two_three_moves(),
+          m_rejected_moves.two_three_moves(),
+          m_attempted_moves.two_three_moves(),
+          m_succeeded_moves.two_three_moves(),
+          m_failed_moves.two_three_moves());
 
-    fmt::print(
-        "(3,2) moves: {} proposed ({} accepted and {} rejected); candidate "
-        "construction: {} attempted ({} succeeded and {} failed).\n",
-        m_proposed_moves.three_two_moves(), m_accepted_moves.three_two_moves(),
-        m_rejected_moves.three_two_moves(), m_attempted_moves.three_two_moves(),
-        m_succeeded_moves.three_two_moves(), m_failed_moves.three_two_moves());
+      fmt::print(
+          "(3,2) moves: {} proposed ({} accepted and {} rejected); candidate "
+          "construction: {} attempted ({} succeeded and {} failed).\n",
+          m_proposed_moves.three_two_moves(),
+          m_accepted_moves.three_two_moves(),
+          m_rejected_moves.three_two_moves(),
+          m_attempted_moves.three_two_moves(),
+          m_succeeded_moves.three_two_moves(),
+          m_failed_moves.three_two_moves());
 
-    fmt::print(
-        "(2,6) moves: {} proposed ({} accepted and {} rejected); candidate "
-        "construction: {} attempted ({} succeeded and {} failed).\n",
-        m_proposed_moves.two_six_moves(), m_accepted_moves.two_six_moves(),
-        m_rejected_moves.two_six_moves(), m_attempted_moves.two_six_moves(),
-        m_succeeded_moves.two_six_moves(), m_failed_moves.two_six_moves());
+      fmt::print(
+          "(2,6) moves: {} proposed ({} accepted and {} rejected); candidate "
+          "construction: {} attempted ({} succeeded and {} failed).\n",
+          m_proposed_moves.two_six_moves(), m_accepted_moves.two_six_moves(),
+          m_rejected_moves.two_six_moves(), m_attempted_moves.two_six_moves(),
+          m_succeeded_moves.two_six_moves(), m_failed_moves.two_six_moves());
 
-    fmt::print(
-        "(6,2) moves: {} proposed ({} accepted and {} rejected); candidate "
-        "construction: {} attempted ({} succeeded and {} failed).\n",
-        m_proposed_moves.six_two_moves(), m_accepted_moves.six_two_moves(),
-        m_rejected_moves.six_two_moves(), m_attempted_moves.six_two_moves(),
-        m_succeeded_moves.six_two_moves(), m_failed_moves.six_two_moves());
+      fmt::print(
+          "(6,2) moves: {} proposed ({} accepted and {} rejected); candidate "
+          "construction: {} attempted ({} succeeded and {} failed).\n",
+          m_proposed_moves.six_two_moves(), m_accepted_moves.six_two_moves(),
+          m_rejected_moves.six_two_moves(), m_attempted_moves.six_two_moves(),
+          m_succeeded_moves.six_two_moves(), m_failed_moves.six_two_moves());
 
-    fmt::print(
-        "(4,4) moves: {} proposed ({} accepted and {} rejected); candidate "
-        "construction: {} attempted ({} succeeded and {} failed).\n",
-        m_proposed_moves.four_four_moves(), m_accepted_moves.four_four_moves(),
-        m_rejected_moves.four_four_moves(), m_attempted_moves.four_four_moves(),
-        m_succeeded_moves.four_four_moves(), m_failed_moves.four_four_moves());
-  }  // print_results
-};  // Metropolis
+      fmt::print(
+          "(4,4) moves: {} proposed ({} accepted and {} rejected); candidate "
+          "construction: {} attempted ({} succeeded and {} failed).\n",
+          m_proposed_moves.four_four_moves(),
+          m_accepted_moves.four_four_moves(),
+          m_rejected_moves.four_four_moves(),
+          m_attempted_moves.four_four_moves(),
+          m_succeeded_moves.four_four_moves(),
+          m_failed_moves.four_four_moves());
+    }  // print_results
+  };  // Metropolis
 
-using Metropolis_3 =
-    MoveStrategy<Strategies::METROPOLIS, manifolds::Manifold_3>;
+  using Metropolis_3 =
+      MoveStrategy<Strategies::METROPOLIS, manifolds::Manifold_3>;
+}  // namespace cdt
 
 #endif  // INCLUDE_METROPOLIS_HPP_

--- a/include/Move_always.hpp
+++ b/include/Move_always.hpp
@@ -19,171 +19,174 @@
 #include "Move_strategy.hpp"
 #include "Random.hpp"
 
-/// @brief The Move Always algorithm
-template <typename ManifoldType>
-  requires(ManifoldType::dimension == 3)
-class MoveStrategy<Strategies::MOVE_ALWAYS, ManifoldType>  // NOLINT
+namespace cdt
 {
-  using Counter = move_tracker::MoveTracker<ManifoldType>;
-
-  /// @brief The number of move passes executed by the algorithm
-  /// @details Each move pass makes a number of attempts equal to the number
-  /// of simplices in the triangulation.
-  Int_precision m_passes{1};
-
-  /// @brief The number of passes before a checkpoint
-  /// @details Each checkpoint writes a file containing the current
-  /// triangulation.
-  Int_precision m_checkpoint{1};
-
-  /// @brief Run-owned random stream used for move selection and site ordering
-  cdt::Random m_random;
-
-  /// @brief The number of moves that were attempted by a MoveCommand
-  Counter m_attempted_moves;
-
-  /// @brief The number of moves that succeeded in the MoveCommand
-  Counter m_successful_moves;
-
-  /// @brief The number of moves that a MoveCommand failed to make due to an
-  /// error.
-  Counter m_failed_moves;
-
- public:
-  /// @brief Default ctor
-  MoveStrategy() = default;
-
-  /// @brief Constructor for MoveAlways
-  /// @param t_number_of_passes Number of passes to run
-  /// @param t_checkpoint Number of passes per checkpoint
-  [[maybe_unused]] MoveStrategy(Int_precision const t_number_of_passes,
-                                Int_precision const t_checkpoint)
-      : MoveStrategy{t_number_of_passes, t_checkpoint, cdt::Random{}}
-  {}
-
-  /// @brief Construct a replayable MoveAlways run from an explicit seed.
-  [[maybe_unused]] MoveStrategy(Int_precision const    t_number_of_passes,
-                                Int_precision const    t_checkpoint,
-                                cdt::Random_seed const seed)
-      : MoveStrategy{t_number_of_passes, t_checkpoint, cdt::Random{seed}}
-  {}
-
-  /// @brief Construct a MoveAlways run from an owned PCG stream.
-  [[maybe_unused]] MoveStrategy(Int_precision const t_number_of_passes,
-                                Int_precision const t_checkpoint,
-                                cdt::Random         random)
-      : m_passes{t_number_of_passes}
-      , m_checkpoint{t_checkpoint}
-      , m_random{std::move(random)}
+  /// @brief The Move Always algorithm
+  template <typename ManifoldType>
+    requires(ManifoldType::dimension == 3)
+  class MoveStrategy<Strategies::MOVE_ALWAYS, ManifoldType>  // NOLINT
   {
-    if (m_passes < 0)
+    using Counter = move_tracker::MoveTracker<ManifoldType>;
+
+    /// @brief The number of move passes executed by the algorithm
+    /// @details Each move pass makes a number of attempts equal to the number
+    /// of simplices in the triangulation.
+    Int_precision m_passes{1};
+
+    /// @brief The number of passes before a checkpoint
+    /// @details Each checkpoint writes a file containing the current
+    /// triangulation.
+    Int_precision m_checkpoint{1};
+
+    /// @brief Run-owned random stream used for move selection and site ordering
+    cdt::Random m_random;
+
+    /// @brief The number of moves that were attempted by a MoveCommand
+    Counter m_attempted_moves;
+
+    /// @brief The number of moves that succeeded in the MoveCommand
+    Counter m_successful_moves;
+
+    /// @brief The number of moves that a MoveCommand failed to make due to an
+    /// error.
+    Counter m_failed_moves;
+
+   public:
+    /// @brief Default ctor
+    MoveStrategy() = default;
+
+    /// @brief Constructor for MoveAlways
+    /// @param t_number_of_passes Number of passes to run
+    /// @param t_checkpoint Number of passes per checkpoint
+    [[maybe_unused]] MoveStrategy(Int_precision const t_number_of_passes,
+                                  Int_precision const t_checkpoint)
+        : MoveStrategy{t_number_of_passes, t_checkpoint, cdt::Random{}}
+    {}
+
+    /// @brief Construct a replayable MoveAlways run from an explicit seed.
+    [[maybe_unused]] MoveStrategy(Int_precision const    t_number_of_passes,
+                                  Int_precision const    t_checkpoint,
+                                  cdt::Random_seed const seed)
+        : MoveStrategy{t_number_of_passes, t_checkpoint, cdt::Random{seed}}
+    {}
+
+    /// @brief Construct a MoveAlways run from an owned PCG stream.
+    [[maybe_unused]] MoveStrategy(Int_precision const t_number_of_passes,
+                                  Int_precision const t_checkpoint,
+                                  cdt::Random         random)
+        : m_passes{t_number_of_passes}
+        , m_checkpoint{t_checkpoint}
+        , m_random{std::move(random)}
     {
-      throw std::invalid_argument{"MoveAlways passes cannot be negative"};
+      if (m_passes < 0)
+      {
+        throw std::invalid_argument{"MoveAlways passes cannot be negative"};
+      }
+      if (m_checkpoint <= 0)
+      {
+        throw std::invalid_argument{
+            "MoveAlways checkpoint interval must be positive"};
+      }
     }
-    if (m_checkpoint <= 0)
+
+    /// @returns The number of passes made on a triangulation
+    [[nodiscard]] auto passes() const { return m_passes; }
+
+    /// @returns The number of passes per checkpoint
+    [[nodiscard]] auto checkpoint() const { return m_checkpoint; }
+
+    /// @returns The effective root seed used for this run.
+    [[nodiscard]] auto seed() const noexcept { return m_random.seed(); }
+
+    /// @returns The MoveTracker of attempted moves
+    auto get_attempted() const { return m_attempted_moves; }
+
+    /// @returns The MoveTracker of successful moves
+    auto get_succeeded() const { return m_successful_moves; }
+
+    /// @returns The array of failed moves
+    auto get_failed() const { return m_failed_moves; }
+
+    /// @brief Call operator
+    auto operator()(ManifoldType const& t_manifold) -> ManifoldType
     {
-      throw std::invalid_argument{
-          "MoveAlways checkpoint interval must be positive"};
-    }
-  }
-
-  /// @returns The number of passes made on a triangulation
-  [[nodiscard]] auto passes() const { return m_passes; }
-
-  /// @returns The number of passes per checkpoint
-  [[nodiscard]] auto checkpoint() const { return m_checkpoint; }
-
-  /// @returns The effective root seed used for this run.
-  [[nodiscard]] auto seed() const noexcept { return m_random.seed(); }
-
-  /// @returns The MoveTracker of attempted moves
-  auto get_attempted() const { return m_attempted_moves; }
-
-  /// @returns The MoveTracker of successful moves
-  auto get_succeeded() const { return m_successful_moves; }
-
-  /// @returns The array of failed moves
-  auto get_failed() const { return m_failed_moves; }
-
-  /// @brief Call operator
-  auto operator()(ManifoldType const& t_manifold) -> ManifoldType
-  {
 #ifndef NDEBUG
-    spdlog::debug("{} called.\n", __PRETTY_FUNCTION__);
+      spdlog::debug("{} called.\n", CDT_PRETTY_FUNCTION);
 #endif
-    fmt::print("Starting Move Always algorithm in {}+1 dimensions ...\n",
-               ManifoldType::dimension - 1);
-    fmt::print("Effective random seed: {} (stream {}).\n", m_random.seed(),
-               m_random.stream());
+      fmt::print("Starting Move Always algorithm in {}+1 dimensions ...\n",
+                 ManifoldType::dimension - 1);
+      fmt::print("Effective random seed: {} (stream {}).\n", m_random.seed(),
+                 m_random.stream());
 
-    m_attempted_moves.reset();
-    m_successful_moves.reset();
-    m_failed_moves.reset();
+      m_attempted_moves.reset();
+      m_successful_moves.reset();
+      m_failed_moves.reset();
 
-    // Start the move command
-    MoveCommand command(t_manifold);
+      // Start the move command
+      MoveCommand command(t_manifold);
 
-    fmt::print("Making random moves ...\n");
+      fmt::print("Making random moves ...\n");
 
-    // Loop through passes
-    for (auto pass_number = 1; pass_number <= m_passes; ++pass_number)
-    {
-      fmt::print("=== Pass {} ===\n", pass_number);
-      auto total_simplices_this_pass = command.get_const_results().N3();
-      // Make a random move per simplex
-      for (auto move_attempt = 0; move_attempt < total_simplices_this_pass;
-           ++move_attempt)
+      // Loop through passes
+      for (auto pass_number = 1; pass_number <= m_passes; ++pass_number)
       {
-        // Pick a move to attempt
-        command.enqueue(move_tracker::generate_random_move_3(m_random));
-      }
-      command.execute(m_random);
-      // Update attempted, successful, and failed moves
-      m_attempted_moves += command.get_attempted();
-      m_successful_moves += command.get_succeeded();
-      m_failed_moves += command.get_failed();
-      command.reset_counters();
+        fmt::print("=== Pass {} ===\n", pass_number);
+        auto total_simplices_this_pass = command.get_const_results().N3();
+        // Make a random move per simplex
+        for (auto move_attempt = 0; move_attempt < total_simplices_this_pass;
+             ++move_attempt)
+        {
+          // Pick a move to attempt
+          command.enqueue(move_tracker::generate_random_move_3(m_random));
+        }
+        command.execute(m_random);
+        // Update attempted, successful, and failed moves
+        m_attempted_moves += command.get_attempted();
+        m_successful_moves += command.get_succeeded();
+        m_failed_moves += command.get_failed();
+        command.reset_counters();
 
-      if (pass_number % m_checkpoint == 0)
-      {
-        fmt::print("Writing checkpoint for pass {}.\n", pass_number);
-        print_results();
-        utilities::write_file(command.get_results(), m_random.seed(),
-                              pass_number);
+        if (pass_number % m_checkpoint == 0)
+        {
+          fmt::print("Writing checkpoint for pass {}.\n", pass_number);
+          print_results();
+          utilities::write_file(command.get_results(), m_random.seed(),
+                                pass_number);
+        }
       }
+      print_results();
+      return command.get_results();
     }
-    print_results();
-    return command.get_results();
-  }
 
-  /// @brief Display results of run
-  void print_results()
-  {
-    fmt::print("=== Move Results ===\n");
-    fmt::print("(2,3) moves: {} attempted = {} successful and {} failed.\n",
-               m_attempted_moves.two_three_moves(),
-               m_successful_moves.two_three_moves(),
-               m_failed_moves.two_three_moves());
-    fmt::print("(3,2) moves: {} attempted = {} successful and {} failed.\n",
-               m_attempted_moves.three_two_moves(),
-               m_successful_moves.three_two_moves(),
-               m_failed_moves.three_two_moves());
-    fmt::print("(2,6) moves: {} attempted = {} successful and {} failed.\n",
-               m_attempted_moves.two_six_moves(),
-               m_successful_moves.two_six_moves(),
-               m_failed_moves.two_six_moves());
-    fmt::print("(6,2) moves: {} attempted = {} successful and {} failed.\n",
-               m_attempted_moves.six_two_moves(),
-               m_successful_moves.six_two_moves(),
-               m_failed_moves.six_two_moves());
-    fmt::print("(4,4) moves: {} attempted = {} successful and {} failed.\n",
-               m_attempted_moves.four_four_moves(),
-               m_successful_moves.four_four_moves(),
-               m_failed_moves.four_four_moves());
-  }
-};
+    /// @brief Display results of run
+    void print_results()
+    {
+      fmt::print("=== Move Results ===\n");
+      fmt::print("(2,3) moves: {} attempted = {} successful and {} failed.\n",
+                 m_attempted_moves.two_three_moves(),
+                 m_successful_moves.two_three_moves(),
+                 m_failed_moves.two_three_moves());
+      fmt::print("(3,2) moves: {} attempted = {} successful and {} failed.\n",
+                 m_attempted_moves.three_two_moves(),
+                 m_successful_moves.three_two_moves(),
+                 m_failed_moves.three_two_moves());
+      fmt::print("(2,6) moves: {} attempted = {} successful and {} failed.\n",
+                 m_attempted_moves.two_six_moves(),
+                 m_successful_moves.two_six_moves(),
+                 m_failed_moves.two_six_moves());
+      fmt::print("(6,2) moves: {} attempted = {} successful and {} failed.\n",
+                 m_attempted_moves.six_two_moves(),
+                 m_successful_moves.six_two_moves(),
+                 m_failed_moves.six_two_moves());
+      fmt::print("(4,4) moves: {} attempted = {} successful and {} failed.\n",
+                 m_attempted_moves.four_four_moves(),
+                 m_successful_moves.four_four_moves(),
+                 m_failed_moves.four_four_moves());
+    }
+  };
 
-using MoveAlways_3 =
-    MoveStrategy<Strategies::MOVE_ALWAYS, manifolds::Manifold_3>;
+  using MoveAlways_3 =
+      MoveStrategy<Strategies::MOVE_ALWAYS, manifolds::Manifold_3>;
+}  // namespace cdt
 
 #endif  // INCLUDE_MOVE_ALWAYS_HPP_

--- a/include/Move_command.hpp
+++ b/include/Move_command.hpp
@@ -16,216 +16,221 @@
 #include "Ergodic_moves_3.hpp"
 #include "Random.hpp"
 
-template <typename ManifoldType,
-          typename ExpectedType = std::expected<ManifoldType, std::string>>
-  requires(ManifoldType::dimension == 3)
-class MoveCommand
+namespace cdt
 {
-  using Queue   = std::deque<move_tracker::move_type>;
-  using Counter = move_tracker::MoveTracker<ManifoldType>;
-
-  /**
-   * \brief The manifold on which to perform moves
-   */
-  ManifoldType m_manifold;
-
-  /**
-   * \brief The queue of moves to perform
-   */
-  Queue m_moves;
-
-  /**
-   * \brief The counter of attempted moves
-   */
-  Counter m_attempted;
-
-  /**
-   * \brief The counter of successful moves
-   */
-  Counter m_succeeded;
-
-  /**
-   * \brief The counter of failed moves
-   */
-  Counter m_failed;
-
- public:
-  /**
-   * \brief Remove default ctor
-   */
-  MoveCommand() = delete;
-
-  /**
-   * \brief MoveCommand ctor
-   * \param t_manifold The manifold to perform moves on
-   * \details The manifold to perform moves upon should be copied by value into
-   * the MoveCommand to ensure moves are executed atomically and either succeed
-   * or fail and can be discarded without affecting the original manifold.
-   */
-  explicit MoveCommand(ManifoldType t_manifold)
-      : m_manifold{std::move(t_manifold)}
-  {}
-
-  /**
-   * \brief A read-only reference to the manifold
-   */
-  auto get_const_results() const -> ManifoldType const&
-  { return m_manifold; }  // get_const_results
-
-  /**
-   * \brief Results of the moves invoked by MoveCommand
-   */
-  [[nodiscard]] auto get_results() -> ManifoldType& { return m_manifold; }
-
-  /**
-   * \brief Attempted moves by MoveCommand
-   */
-  [[nodiscard]] auto get_attempted() const -> Counter const&
-  { return m_attempted; }  // get_attempts
-
-  /**
-   * \brief Successful moves by MoveCommand
-   */
-  [[nodiscard]] auto get_succeeded() const -> Counter const&
-  { return m_succeeded; }  // get_succeeded
-
-  /**
-   * \brief Failed moves by MoveCommand
-   */
-  [[nodiscard]] auto get_failed() const -> Counter const&
-  { return m_failed; }  // get_errors
-
-  /**
-   * \brief Reset counters
-   */
-  void reset_counters()
+  template <typename ManifoldType,
+            typename ExpectedType = std::expected<ManifoldType, std::string>>
+    requires(ManifoldType::dimension == 3)
+  class MoveCommand
   {
-    m_attempted.reset();
-    m_succeeded.reset();
-    m_failed.reset();
-  }
+    using Queue   = std::deque<move_tracker::move_type>;
+    using Counter = move_tracker::MoveTracker<ManifoldType>;
 
-  /**
-   * \brief Push a Pachner move onto the move queue
-   * \param t_move The move to add
-   */
-  void enqueue(move_tracker::move_type const t_move)
-  { m_moves.push_front(t_move); }
+    /**
+     * \brief The manifold on which to perform moves
+     */
+    ManifoldType m_manifold;
 
-  /**
-   * \brief The number of moves on the queue
-   */
-  auto size() const { return m_moves.size(); }
+    /**
+     * \brief The queue of moves to perform
+     */
+    Queue m_moves;
 
-  /**
-   * \brief Execute all moves in the queue on the manifold
-   */
-  template <std::uniform_random_bit_generator Generator>
-  void execute(Generator& generator)
-  {
-    while (!m_moves.empty())
+    /**
+     * \brief The counter of attempted moves
+     */
+    Counter m_attempted;
+
+    /**
+     * \brief The counter of successful moves
+     */
+    Counter m_succeeded;
+
+    /**
+     * \brief The counter of failed moves
+     */
+    Counter m_failed;
+
+   public:
+    /**
+     * \brief Remove default ctor
+     */
+    MoveCommand() = delete;
+
+    /**
+     * \brief MoveCommand ctor
+     * \param t_manifold The manifold to perform moves on
+     * \details The manifold to perform moves upon should be copied by value
+     * into the MoveCommand to ensure moves are executed atomically and either
+     * succeed or fail and can be discarded without affecting the original
+     * manifold.
+     */
+    explicit MoveCommand(ManifoldType t_manifold)
+        : m_manifold{std::move(t_manifold)}
+    {}
+
+    /**
+     * \brief A read-only reference to the manifold
+     */
+    auto get_const_results() const -> ManifoldType const&
+    { return m_manifold; }  // get_const_results
+
+    /**
+     * \brief Results of the moves invoked by MoveCommand
+     */
+    [[nodiscard]] auto get_results() -> ManifoldType& { return m_manifold; }
+
+    /**
+     * \brief Attempted moves by MoveCommand
+     */
+    [[nodiscard]] auto get_attempted() const -> Counter const&
+    { return m_attempted; }  // get_attempts
+
+    /**
+     * \brief Successful moves by MoveCommand
+     */
+    [[nodiscard]] auto get_succeeded() const -> Counter const&
+    { return m_succeeded; }  // get_succeeded
+
+    /**
+     * \brief Failed moves by MoveCommand
+     */
+    [[nodiscard]] auto get_failed() const -> Counter const&
+    { return m_failed; }  // get_errors
+
+    /**
+     * \brief Reset counters
+     */
+    void reset_counters()
     {
-      auto move_type = m_moves.back();
-      // Record attempted move
-      ++m_attempted[as_integer(move_type)];
-      if (auto result = apply_random_move(std::as_const(m_manifold), move_type,
-                                          generator);
-          result)
+      m_attempted.reset();
+      m_succeeded.reset();
+      m_failed.reset();
+    }
+
+    /**
+     * \brief Push a Pachner move onto the move queue
+     * \param t_move The move to add
+     */
+    void enqueue(move_tracker::move_type const t_move)
+    { m_moves.push_front(t_move); }
+
+    /**
+     * \brief The number of moves on the queue
+     */
+    auto size() const { return m_moves.size(); }
+
+    /**
+     * \brief Execute all moves in the queue on the manifold
+     */
+    template <std::uniform_random_bit_generator Generator>
+    void execute(Generator& generator)
+    {
+      while (!m_moves.empty())
       {
-        if (ergodic_moves::check_move(m_manifold, *result, move_type))
+        auto move_type = m_moves.back();
+        // Record attempted move
+        ++m_attempted[as_integer(move_type)];
+        if (auto result = apply_random_move(std::as_const(m_manifold),
+                                            move_type, generator);
+            result)
         {
-          swap(result.value(), m_manifold);
-          ++m_succeeded[as_integer(move_type)];
+          if (ergodic_moves::detail::check_move(m_manifold, *result, move_type))
+          {
+            swap(result.value(), m_manifold);
+            ++m_succeeded[as_integer(move_type)];
+          }
+          else
+          {
+            spdlog::warn(
+                "Move violated a manifold invariant or geometry delta.\n");
+            ++m_failed[as_integer(move_type)];
+          }
         }
         else
         {
-          spdlog::warn(
-              "Move violated a manifold invariant or geometry delta.\n");
+          // Routine inapplicable sites are represented by the failed counter.
           ++m_failed[as_integer(move_type)];
         }
+        // Remove move from queue
+        m_moves.pop_back();
+      }
+    }  // execute
+
+    /// @brief Apply one queued move using the caller-owned random stream.
+    template <std::uniform_random_bit_generator Generator>
+    static auto apply_random_move(ManifoldType const&           manifold,
+                                  move_tracker::move_type const move,
+                                  Generator& generator) -> ExpectedType
+    {
+      using enum move_tracker::move_type;
+      switch (move)
+      {
+        case TWO_THREE: return ergodic_moves::do_23_move(manifold, generator);
+        case THREE_TWO: return ergodic_moves::do_32_move(manifold, generator);
+        case TWO_SIX: return ergodic_moves::do_26_move(manifold, generator);
+        case SIX_TWO: return ergodic_moves::do_62_move(manifold, generator);
+        case FOUR_FOUR: return ergodic_moves::do_44_move(manifold, generator);
+      }
+      return std::unexpected("Unknown Pachner move.");
+    }
+
+    /**
+     * \brief Print attempted moves
+     */
+    void print_attempts() const
+    {
+      fmt::print(
+          "There were {} attempted (2,3) moves and {} attempted (3,2) moves "
+          "and {} "
+          "attempted (2,6) moves and {} attempted (6,2) moves and {} attempted "
+          "(4,4) "
+          "moves.\n",
+          m_attempted.two_three_moves(), m_attempted.three_two_moves(),
+          m_attempted.two_six_moves(), m_attempted.six_two_moves(),
+          m_attempted.four_four_moves());
+    }
+
+    /**
+     * \brief Print successful moves
+     */
+    void print_successful() const
+    {
+      fmt::print(
+          "There were {} successful (2,3) moves and {} successful (3,2) moves "
+          "and {} "
+          "successful (2,6) moves and {} successful (6,2) moves and {} "
+          "successful "
+          "(4,4) "
+          "moves.\n",
+          m_succeeded.two_three_moves(), m_succeeded.three_two_moves(),
+          m_succeeded.two_six_moves(), m_succeeded.six_two_moves(),
+          m_succeeded.four_four_moves());
+    }
+
+    /**
+     * \brief Print move errors
+     */
+    void print_errors() const
+    {
+      if (std::all_of(m_failed.moves_view().begin(),
+                      m_failed.moves_view().end(),
+                      [](auto const& value) { return value == 0; }))
+      {
+        fmt::print("There were no failed moves.\n");
       }
       else
       {
-        // Routine inapplicable sites are represented by the failed counter.
-        ++m_failed[as_integer(move_type)];
+        fmt::print(
+            "There were {} failed (2,3) moves and {} failed (3,2) moves and {} "
+            "failed (2,6) moves and {} failed (6,2) moves and {} failed (4,4) "
+            "moves.\n",
+            m_failed.two_three_moves(), m_failed.three_two_moves(),
+            m_failed.two_six_moves(), m_failed.six_two_moves(),
+            m_failed.four_four_moves());
       }
-      // Remove move from queue
-      m_moves.pop_back();
     }
-  }  // execute
-
-  /// @brief Apply one queued move using the caller-owned random stream.
-  template <std::uniform_random_bit_generator Generator>
-  static auto apply_random_move(ManifoldType const&           manifold,
-                                move_tracker::move_type const move,
-                                Generator& generator) -> ExpectedType
-  {
-    using enum move_tracker::move_type;
-    switch (move)
-    {
-      case TWO_THREE: return ergodic_moves::do_23_move(manifold, generator);
-      case THREE_TWO: return ergodic_moves::do_32_move(manifold, generator);
-      case TWO_SIX: return ergodic_moves::do_26_move(manifold, generator);
-      case SIX_TWO: return ergodic_moves::do_62_move(manifold, generator);
-      case FOUR_FOUR: return ergodic_moves::do_44_move(manifold, generator);
-    }
-    return std::unexpected("Unknown Pachner move.");
-  }
-
-  /**
-   * \brief Print attempted moves
-   */
-  void print_attempts() const
-  {
-    fmt::print(
-        "There were {} attempted (2,3) moves and {} attempted (3,2) moves "
-        "and {} "
-        "attempted (2,6) moves and {} attempted (6,2) moves and {} attempted "
-        "(4,4) "
-        "moves.\n",
-        m_attempted.two_three_moves(), m_attempted.three_two_moves(),
-        m_attempted.two_six_moves(), m_attempted.six_two_moves(),
-        m_attempted.four_four_moves());
-  }
-
-  /**
-   * \brief Print successful moves
-   */
-  void print_successful() const
-  {
-    fmt::print(
-        "There were {} successful (2,3) moves and {} successful (3,2) moves "
-        "and {} "
-        "successful (2,6) moves and {} successful (6,2) moves and {} "
-        "successful "
-        "(4,4) "
-        "moves.\n",
-        m_succeeded.two_three_moves(), m_succeeded.three_two_moves(),
-        m_succeeded.two_six_moves(), m_succeeded.six_two_moves(),
-        m_succeeded.four_four_moves());
-  }
-
-  /**
-   * \brief Print move errors
-   */
-  void print_errors() const
-  {
-    if (std::all_of(m_failed.moves_view().begin(), m_failed.moves_view().end(),
-                    [](auto const& value) { return value == 0; }))
-    {
-      fmt::print("There were no failed moves.\n");
-    }
-    else
-    {
-      fmt::print(
-          "There were {} failed (2,3) moves and {} failed (3,2) moves and {} "
-          "failed (2,6) moves and {} failed (6,2) moves and {} failed (4,4) "
-          "moves.\n",
-          m_failed.two_three_moves(), m_failed.three_two_moves(),
-          m_failed.two_six_moves(), m_failed.six_two_moves(),
-          m_failed.four_four_moves());
-    }
-  }
-};
+  };
+}  // namespace cdt
 
 #endif  // CDT_PLUSPLUS_MOVECOMMAND_HPP

--- a/include/Move_strategy.hpp
+++ b/include/Move_strategy.hpp
@@ -13,22 +13,25 @@
 #ifndef INCLUDE_MOVE_STRATEGY_HPP_
 #define INCLUDE_MOVE_STRATEGY_HPP_
 
-/**
- * \brief The algorithms available to make ergodic moves on triangulations
- */
-enum class Strategies
+namespace cdt
 {
-  MOVE_ALWAYS,
-  METROPOLIS
-};
+  /**
+   * \brief The algorithms available to make ergodic moves on triangulations
+   */
+  enum class Strategies
+  {
+    MOVE_ALWAYS,
+    METROPOLIS
+  };
 
-/**
- * \brief Select a move algorithm
- * \tparam strategies The move algorithm to use
- * \tparam ManifoldType The manifold to perform moves on
- */
-template <Strategies strategies, typename ManifoldType>
-class MoveStrategy
-{};
+  /**
+   * \brief Select a move algorithm
+   * \tparam strategies The move algorithm to use
+   * \tparam ManifoldType The manifold to perform moves on
+   */
+  template <Strategies strategies, typename ManifoldType>
+  class MoveStrategy
+  {};
+}  // namespace cdt
 
 #endif  // INCLUDE_MOVE_STRATEGY_HPP_

--- a/include/Move_tracker.hpp
+++ b/include/Move_tracker.hpp
@@ -21,9 +21,9 @@
 #include "Settings.hpp"
 #include "Utilities.hpp"
 
-namespace move_tracker
+namespace cdt::move_tracker
 {
-  static inline Int_precision constexpr NUMBER_OF_3D_MOVES = 5;
+  inline Int_precision constexpr NUMBER_OF_3D_MOVES = 5;
 
   /**
    * \brief The types of 3D ergodic moves
@@ -212,6 +212,6 @@ namespace move_tracker
     void reset() { moves.fill(0); }
   };
 
-}  // namespace move_tracker
+}  // namespace cdt::move_tracker
 
 #endif  // CDT_PLUSPLUS_MOVE_TRACKER_HPP

--- a/include/Mpfr_value.hpp
+++ b/include/Mpfr_value.hpp
@@ -17,16 +17,16 @@
 
 #include "Settings.hpp"
 
-namespace mpfr_values
+namespace cdt::mpfr_values
 {
-  using Value                                = CGAL::Gmpfr;
+  using Value                         = CGAL::Gmpfr;
 
   /// MPFR round-to-nearest with ties to an even significand.
   ///
   /// Keeping one explicit policy at every arithmetic boundary prevents a
   /// caller from accidentally mixing directed roundings inside an action
   /// calculation.
-  static inline auto constexpr rounding_mode = MPFR_RNDN;
+  inline auto constexpr rounding_mode = MPFR_RNDN;
 
   static_assert(std::is_nothrow_destructible_v<Value>,
                 "MPFR values must release their resources without throwing.");
@@ -142,6 +142,6 @@ namespace mpfr_values
 
   [[nodiscard]] inline auto to_long_double(Value const& value) -> long double
   { return mpfr_get_ld(value.fr(), rounding_mode); }
-}  // namespace mpfr_values
+}  // namespace cdt::mpfr_values
 
 #endif  // CDT_PLUSPLUS_MPFR_VALUE_HPP

--- a/include/Periodic_3_complex.hpp
+++ b/include/Periodic_3_complex.hpp
@@ -21,34 +21,38 @@
 #include <cassert>
 #include <vector>
 
-using K   = CGAL::Exact_predicates_inexact_constructions_kernel;
-using GT  = CGAL::Periodic_3_triangulation_traits_3<K>;
-using PDT = CGAL::Periodic_3_Delaunay_triangulation_3<GT>;
-
-/// Make 3D toroidal (periodic in 3D) simplicial complexes
-void make_random_T3_simplicial_complex(PDT* T3, int number_of_simplices)
+namespace cdt::experimental::periodic_complex
 {
-  typedef CGAL::Creator_uniform_3<double, PDT::Point> Creator;
-  CGAL::Random                                        random(7);
-  CGAL::Random_points_in_cube_3<PDT::Point, Creator>  in_cube(.5, random);
+  using K   = CGAL::Exact_predicates_inexact_constructions_kernel;
+  using GT  = CGAL::Periodic_3_triangulation_traits_3<K>;
+  using PDT = CGAL::Periodic_3_Delaunay_triangulation_3<GT>;
 
-  /// We can't directly pick number of simplices as we can in S3
-  /// but heuristically a point has <6 simplices
-  int                     n = number_of_simplices / 6;
-  std::vector<PDT::Point> pts;
-
-  // Generate random points
-  for (int i = 0; i < n; i++)
+  /// Make 3D toroidal (periodic in 3D) simplicial complexes
+  inline void make_random_T3_simplicial_complex(PDT* T3,
+                                                int  number_of_simplices)
   {
-    PDT::Point p = *in_cube;
-    in_cube++;
-    pts.emplace_back(PDT::Point(p.x() + .5, p.y() + .5, p.z() + .5));
+    typedef CGAL::Creator_uniform_3<double, PDT::Point> Creator;
+    CGAL::Random                                        random(7);
+    CGAL::Random_points_in_cube_3<PDT::Point, Creator>  in_cube(.5, random);
+
+    /// We can't directly pick number of simplices as we can in S3
+    /// but heuristically a point has <6 simplices
+    int                     n = number_of_simplices / 6;
+    std::vector<PDT::Point> pts;
+
+    // Generate random points
+    for (int i = 0; i < n; i++)
+    {
+      PDT::Point p = *in_cube;
+      in_cube++;
+      pts.emplace_back(PDT::Point(p.x() + .5, p.y() + .5, p.z() + .5));
+    }
+
+    // Iterator range insertion using spatial sorting and dummy point heuristic
+    T3->insert(pts.begin(), pts.end(), true);
+
+    assert(T3->dimension() == 3);
+    assert(T3->is_valid());
   }
-
-  // Iterator range insertion using spatial sorting and dummy point heuristic
-  T3->insert(pts.begin(), pts.end(), true);
-
-  assert(T3->dimension() == 3);
-  assert(T3->is_valid());
-}
+}  // namespace cdt::experimental::periodic_complex
 #endif  // INCLUDE_PERIODIC_3_COMPLEX_HPP_

--- a/include/Periodic_3_triangulations.hpp
+++ b/include/Periodic_3_triangulations.hpp
@@ -22,62 +22,69 @@
 #include <cassert>
 #include <vector>
 
-using K       = CGAL::Exact_predicates_inexact_constructions_kernel;
-using GT      = CGAL::Periodic_3_triangulation_filtered_traits_3<K>;
-
-using VbDS    = CGAL::Periodic_3_triangulation_ds_vertex_base_3<>;
-using T3Vb    = CGAL::Triangulation_vertex_base_3<GT, VbDS>;
-
-using CbDS    = CGAL::Periodic_3_triangulation_ds_cell_base_3<>;
-using Cb      = CGAL::Triangulation_cell_base_3<GT, CbDS>;
-
-/// Allows each vertex to contain an integer denoting its timeslice
-using VbInfo  = CGAL::Triangulation_vertex_base_with_info_3<int, GT, T3Vb>;
-using TDS     = CGAL::Triangulation_data_structure_3<VbInfo, Cb>;
-using PDT     = CGAL::Periodic_3_Delaunay_triangulation_3<GT, TDS>;
-using T3Point = PDT::Point;
-
-/// Random point generators for d-dimensional points in a d-cube per timeslice
-using Kd      = CGAL::Cartesian_d<double>;
-using Point   = Kd::Point_d;
-
-/// Make 3D toroidal (periodic) triangulations
-template <typename T>
-void make_random_T3_triangulation(T* T3, int simplices, int timeslices)
+namespace cdt::experimental::periodic_triangulations
 {
-  std::cout << "make_random_T3_triangulation() called" << std::endl;
+  using K       = CGAL::Exact_predicates_inexact_constructions_kernel;
+  using GT      = CGAL::Periodic_3_triangulation_filtered_traits_3<K>;
 
-  int simplices_per_timeslice = simplices / timeslices;
-  /// We can't directly pick number of simplices as we can in S3
-  /// but a point has <6 simplices in 3D
-  int points                  = simplices / 6;
-  int points_per_timeslice    = simplices_per_timeslice / 6;
-  /// We're working on 2 dimensional random points with the z component
-  /// fixed by the timeslice
-  int const          dim      = 2;
+  using VbDS    = CGAL::Periodic_3_triangulation_ds_vertex_base_3<>;
+  using T3Vb    = CGAL::Triangulation_vertex_base_3<GT, VbDS>;
 
-  std::vector<Point> v;
-  v.reserve(points);
+  using CbDS    = CGAL::Periodic_3_triangulation_ds_cell_base_3<>;
+  using Cb      = CGAL::Triangulation_cell_base_3<GT, CbDS>;
 
-  /// In d-dimensions the range of points in a d-cube is the d-th root
-  double                               size = sqrt(points_per_timeslice);
+  /// Allows each vertex to contain an integer denoting its timeslice
+  using VbInfo  = CGAL::Triangulation_vertex_base_with_info_3<int, GT, T3Vb>;
+  using TDS     = CGAL::Triangulation_data_structure_3<VbInfo, Cb>;
+  using PDT     = CGAL::Periodic_3_Delaunay_triangulation_3<GT, TDS>;
+  using T3Point = PDT::Point;
 
-  CGAL::Random_points_in_cube_d<Point> gen(dim, size);
+  /// Random point generators for d-dimensional points in a d-cube per timeslice
+  using Kd      = CGAL::Cartesian_d<double>;
+  using Point   = Kd::Point_d;
 
-  /// Setup random point creation in a square (2-cube)
-  for (int timeslice_index = 0; timeslice_index < timeslices; ++timeslice_index)
+  /// Make 3D toroidal (periodic) triangulations
+  template <typename T>
+  void make_random_T3_triangulation(T* T3, int simplices, int timeslices)
   {
-    /// Debugging
-    std::cout << "Timeslice " << timeslice_index << std::endl;
-    for (int point_index = 0; point_index < points_per_timeslice; ++point_index)
+    std::cout << "make_random_T3_triangulation() called" << std::endl;
+
+    int simplices_per_timeslice = simplices / timeslices;
+    /// We can't directly pick number of simplices as we can in S3
+    /// but a point has <6 simplices in 3D
+    int points                  = simplices / 6;
+    int points_per_timeslice    = simplices_per_timeslice / 6;
+    /// We're working on 2 dimensional random points with the z component
+    /// fixed by the timeslice
+    int const          dim      = 2;
+
+    std::vector<Point> v;
+    v.reserve(points);
+
+    /// In d-dimensions the range of points in a d-cube is the d-th root
+    double                               size = sqrt(points_per_timeslice);
+
+    CGAL::Random_points_in_cube_d<Point> gen(dim, size);
+
+    /// Setup random point creation in a square (2-cube)
+    for (int timeslice_index = 0; timeslice_index < timeslices;
+         ++timeslice_index)
     {
-      v.push_back(*gen++);
-    }
-    for (int point_index = 0; point_index < points_per_timeslice; ++point_index)
-    {
-      auto const offset = timeslice_index * points_per_timeslice + point_index;
-      std::cout << " " << v[static_cast<std::size_t>(offset)] << std::endl;
+      /// Debugging
+      std::cout << "Timeslice " << timeslice_index << std::endl;
+      for (int point_index = 0; point_index < points_per_timeslice;
+           ++point_index)
+      {
+        v.push_back(*gen++);
+      }
+      for (int point_index = 0; point_index < points_per_timeslice;
+           ++point_index)
+      {
+        auto const offset =
+            timeslice_index * points_per_timeslice + point_index;
+        std::cout << " " << v[static_cast<std::size_t>(offset)] << std::endl;
+      }
     }
   }
-}
+}  // namespace cdt::experimental::periodic_triangulations
 #endif  // INCLUDE_PERIODIC_3_TRIANGULATIONS_HPP_

--- a/include/Runtime_config.hpp
+++ b/include/Runtime_config.hpp
@@ -19,7 +19,7 @@
 #include "Random.hpp"
 #include "Utilities.hpp"
 
-namespace runtime_config
+namespace cdt::runtime_config
 {
   /// Parameters shared by triangulation-producing command-line programs.
   /// @details Instances can only be created by make_triangulation(), so the
@@ -307,6 +307,6 @@ namespace runtime_config
                       checked_lambda, checked_passes, checked_checkpoint,
                       write_files};
   }
-}  // namespace runtime_config
+}  // namespace cdt::runtime_config
 
 #endif  // CDT_PLUSPLUS_RUNTIME_CONFIG_HPP

--- a/include/S3Action.hpp
+++ b/include/S3Action.hpp
@@ -28,7 +28,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcomment"
 
-namespace s3_action
+namespace cdt::s3_action
 {
   struct PhysicalParameters
   {
@@ -63,269 +63,272 @@ namespace s3_action
     }
     return {k, lambda};
   }
-}  // namespace s3_action
+  /// @brief Calculates S3 bulk action for \f$\alpha\f$=-1.
+  ///
+  /// This result is i* the action for Euclidean dynamically triangulated
+  /// gravity in three dimensions.
+  /// The formula is:
+  ///
+  /// \f[S^{(3)}(\alpha=-1)=-2\pi ik N_1^{TL}+N_3^{(3,1)}\left(2.673ik+0.118i
+  /// \lambda\right)+N_3^{(2,2)}\left(7.386ik+0.118i\lambda\right)
+  /// \equiv iS^3_{EDT}\f]
+  ///
+  /// @param N1_TL  \f$N_1^{TL}\f$ is the number of timelike links
+  /// @param N3_31_13  \f$N_3^{(3,1)}\f$ is the number of (3,1) and (1,3)
+  /// simplices
+  /// @param N3_22  \f$N_3^{(2,2)}\f$ is the number of (2,2) simplices
+  /// @param K      \f$k=\frac{1}{8\pi G_{Newton}}\f$
+  /// @param Lambda \f$\lambda=k*\Lambda\f$ where \f$\Lambda\f$ is the
+  ///                   Cosmological constant
+  /// @returns \f$S^{(3)}(\alpha=-1)\f$ as a 256-bit MPFR value
+  [[nodiscard]] inline auto S3_bulk_action_alpha_minus_one(
+      Int_precision const N1_TL, Int_precision const N3_31_13,
+      Int_precision const N3_22, long double const K, long double const Lambda)
+      -> mpfr_values::Value
+  {
+    auto const [checked_k, checked_lambda] =
+        s3_action::make_finite_couplings(K, Lambda);
 
-/// @brief Calculates S3 bulk action for \f$\alpha\f$=-1.
-///
-/// This result is i* the action for Euclidean dynamically triangulated
-/// gravity in three dimensions.
-/// The formula is:
-///
-/// \f[S^{(3)}(\alpha=-1)=-2\pi ik N_1^{TL}+N_3^{(3,1)}\left(2.673ik+0.118i
-/// \lambda\right)+N_3^{(2,2)}\left(7.386ik+0.118i\lambda\right)
-/// \equiv iS^3_{EDT}\f]
-///
-/// @param N1_TL  \f$N_1^{TL}\f$ is the number of timelike links
-/// @param N3_31_13  \f$N_3^{(3,1)}\f$ is the number of (3,1) and (1,3)
-/// simplices
-/// @param N3_22  \f$N_3^{(2,2)}\f$ is the number of (2,2) simplices
-/// @param K      \f$k=\frac{1}{8\pi G_{Newton}}\f$
-/// @param Lambda \f$\lambda=k*\Lambda\f$ where \f$\Lambda\f$ is the
-///                   Cosmological constant
-/// @returns \f$S^{(3)}(\alpha=-1)\f$ as a 256-bit MPFR value
-[[nodiscard]] inline auto S3_bulk_action_alpha_minus_one(
-    Int_precision const N1_TL, Int_precision const N3_31_13,
-    Int_precision const N3_22, long double const K, long double const Lambda)
-    -> mpfr_values::Value
-{
-  auto const [checked_k, checked_lambda] =
-      s3_action::make_finite_couplings(K, Lambda);
+    // Set input parameters and constants to MPFR equivalents
+    auto const n1_tl     = mpfr_values::from_integer(N1_TL);
+    auto const n3_31     = mpfr_values::from_integer(N3_31_13);
+    auto const n3_22     = mpfr_values::from_integer(N3_22);
+    auto const k         = mpfr_values::from_long_double(checked_k);
+    auto const lambda    = mpfr_values::from_long_double(checked_lambda);
+    auto const two       = mpfr_values::from_integer(2);
+    auto const pi        = mpfr_values::pi();
+    auto const const2673 = mpfr_values::from_decimal("2.673");
+    auto const const118  = mpfr_values::from_decimal("0.118");
+    auto const const7386 = mpfr_values::from_decimal("7.386");
 
-  // Set input parameters and constants to MPFR equivalents
-  auto const n1_tl     = mpfr_values::from_integer(N1_TL);
-  auto const n3_31     = mpfr_values::from_integer(N3_31_13);
-  auto const n3_22     = mpfr_values::from_integer(N3_22);
-  auto const k         = mpfr_values::from_long_double(checked_k);
-  auto const lambda    = mpfr_values::from_long_double(checked_lambda);
-  auto const two       = mpfr_values::from_integer(2);
-  auto const pi        = mpfr_values::pi();
-  auto const const2673 = mpfr_values::from_decimal("2.673");
-  auto const const118  = mpfr_values::from_decimal("0.118");
-  auto const const7386 = mpfr_values::from_decimal("7.386");
+    // First term accumulates in r3
+    auto const r1        = mpfr_values::multiply(two, pi);  // r1 = 2*pi
+    auto const r2        = mpfr_values::multiply(r1, k);    // r2 = 2*pi*k
+    auto const r3 = mpfr_values::multiply(r2, n1_tl);       // r3 = 2*pi*k*n1_tl
 
-  // First term accumulates in r3
-  auto const r1        = mpfr_values::multiply(two, pi);    // r1 = 2*pi
-  auto const r2        = mpfr_values::multiply(r1, k);      // r2 = 2*pi*k
-  auto const r3        = mpfr_values::multiply(r2, n1_tl);  // r3 = 2*pi*k*n1_tl
+    // Second term accumulates in r7
+    auto const r4 = mpfr_values::multiply(const2673, k);  // r4 = 2.673*k
+    auto const r5 =
+        mpfr_values::multiply(const118, lambda);       // r5 = 0.118*lambda
+    auto const r6 = mpfr_values::add(r4, r5);          // r6 = r4 + r5
+    auto const r7 = mpfr_values::multiply(n3_31, r6);  // r7 = n3_31*r6
 
-  // Second term accumulates in r7
-  auto const r4        = mpfr_values::multiply(const2673, k);  // r4 = 2.673*k
-  auto const r5 = mpfr_values::multiply(const118, lambda);  // r5 = 0.118*lambda
-  auto const r6 = mpfr_values::add(r4, r5);                 // r6 = r4 + r5
-  auto const r7 = mpfr_values::multiply(n3_31, r6);         // r7 = n3_31*r6
+    // Third term accumulates in r11
+    auto const r8 = mpfr_values::multiply(const7386, k);  // r8 = 7.386*k
+    auto const r9 =
+        mpfr_values::multiply(const118, lambda);           // r9 = 0.118*lambda
+    auto const r10   = mpfr_values::add(r8, r9);           // r10 = r8+r9
+    auto const r11   = mpfr_values::multiply(n3_22, r10);  // r11 = n3_22*r10
 
-  // Third term accumulates in r11
-  auto const r8 = mpfr_values::multiply(const7386, k);      // r8 = 7.386*k
-  auto const r9 = mpfr_values::multiply(const118, lambda);  // r9 = 0.118*lambda
-  auto const r10   = mpfr_values::add(r8, r9);              // r10 = r8+r9
-  auto const r11   = mpfr_values::multiply(n3_22, r10);     // r11 = n3_22*r10
+    // Result is r3+r7+r11
+    auto const r12   = mpfr_values::subtract(r7, r3);  // r12 = r7-r3
+    auto const total = mpfr_values::add(r11, r12);     // total = r11+r12
 
-  // Result is r3+r7+r11
-  auto const r12   = mpfr_values::subtract(r7, r3);  // r12 = r7-r3
-  auto const total = mpfr_values::add(r11, r12);     // total = r11+r12
+    return total;
+  }  // S3_bulk_action_alpha_minus_one()
 
-  return total;
-}  // S3_bulk_action_alpha_minus_one()
+  /// @brief Calculates S3 bulk action for \f$\alpha\f$=1.
+  ///
+  /// The formula is:
+  ///
+  /// \f[S^{(3)}(\alpha=1)=2\pi k N_1^{TL}+N_3^{(3,1)}\left(-3.548k-0.167\lambda
+  /// \right)+N_3^{(2,2)}\left(-5.355k-0.204\lambda\right)\f]
+  ///
+  /// @param N1_TL  \f$N_1^{TL}\f$ is the number of timelike links
+  /// @param N3_31_13  \f$N_3^{(3,1)}\f$ is the number of (3,1) and (1,3)
+  /// simplices
+  /// @param N3_22  \f$N_3^{(2,2)}\f$ is the number of (2,2) simplices
+  /// @param K      \f$k=\frac{1}{8\pi G_{Newton}}\f$
+  /// @param Lambda \f$\lambda=k*\Lambda\f$ where \f$\Lambda\f$ is the
+  ///                   Cosmological constant
+  /// @returns \f$S^{(3)}(\alpha=1)\f$ as a 256-bit MPFR value
+  [[nodiscard]] inline auto S3_bulk_action_alpha_one(
+      Int_precision const N1_TL, Int_precision const N3_31_13,
+      Int_precision const N3_22, long double const K, long double const Lambda)
+      -> mpfr_values::Value
+  {
+    auto const [checked_k, checked_lambda] =
+        s3_action::make_finite_couplings(K, Lambda);
 
-/// @brief Calculates S3 bulk action for \f$\alpha\f$=1.
-///
-/// The formula is:
-///
-/// \f[S^{(3)}(\alpha=1)=2\pi k N_1^{TL}+N_3^{(3,1)}\left(-3.548k-0.167\lambda
-/// \right)+N_3^{(2,2)}\left(-5.355k-0.204\lambda\right)\f]
-///
-/// @param N1_TL  \f$N_1^{TL}\f$ is the number of timelike links
-/// @param N3_31_13  \f$N_3^{(3,1)}\f$ is the number of (3,1) and (1,3)
-/// simplices
-/// @param N3_22  \f$N_3^{(2,2)}\f$ is the number of (2,2) simplices
-/// @param K      \f$k=\frac{1}{8\pi G_{Newton}}\f$
-/// @param Lambda \f$\lambda=k*\Lambda\f$ where \f$\Lambda\f$ is the
-///                   Cosmological constant
-/// @returns \f$S^{(3)}(\alpha=1)\f$ as a 256-bit MPFR value
-[[nodiscard]] inline auto S3_bulk_action_alpha_one(Int_precision const N1_TL,
-                                                   Int_precision const N3_31_13,
-                                                   Int_precision const N3_22,
-                                                   long double const   K,
-                                                   long double const   Lambda)
-    -> mpfr_values::Value
-{
-  auto const [checked_k, checked_lambda] =
-      s3_action::make_finite_couplings(K, Lambda);
+    // Set input parameters and constants to MPFR equivalents
+    auto const n1_tl     = mpfr_values::from_integer(N1_TL);
+    auto const n3_31     = mpfr_values::from_integer(N3_31_13);
+    auto const n3_22     = mpfr_values::from_integer(N3_22);
+    auto const k         = mpfr_values::from_long_double(checked_k);
+    auto const lambda    = mpfr_values::from_long_double(checked_lambda);
+    auto const two       = mpfr_values::from_integer(2);
+    auto const pi        = mpfr_values::pi();
+    auto const const3548 = mpfr_values::from_decimal("-3.548");
+    auto const const167  = mpfr_values::from_decimal("-0.167");
+    auto const const5355 = mpfr_values::from_decimal("-5.355");
+    auto const const204  = mpfr_values::from_decimal("-0.204");
 
-  // Set input parameters and constants to MPFR equivalents
-  auto const n1_tl     = mpfr_values::from_integer(N1_TL);
-  auto const n3_31     = mpfr_values::from_integer(N3_31_13);
-  auto const n3_22     = mpfr_values::from_integer(N3_22);
-  auto const k         = mpfr_values::from_long_double(checked_k);
-  auto const lambda    = mpfr_values::from_long_double(checked_lambda);
-  auto const two       = mpfr_values::from_integer(2);
-  auto const pi        = mpfr_values::pi();
-  auto const const3548 = mpfr_values::from_decimal("-3.548");
-  auto const const167  = mpfr_values::from_decimal("-0.167");
-  auto const const5355 = mpfr_values::from_decimal("-5.355");
-  auto const const204  = mpfr_values::from_decimal("-0.204");
+    // First term accumulates in r3
+    auto const r1        = mpfr_values::multiply(two, pi);  // r1 = 2*pi
+    auto const r2        = mpfr_values::multiply(r1, k);    // r2 = 2*pi*k
+    auto const r3 = mpfr_values::multiply(r2, n1_tl);       // r3 = 2*pi*k*n1_tl
 
-  // First term accumulates in r3
-  auto const r1        = mpfr_values::multiply(two, pi);    // r1 = 2*pi
-  auto const r2        = mpfr_values::multiply(r1, k);      // r2 = 2*pi*k
-  auto const r3        = mpfr_values::multiply(r2, n1_tl);  // r3 = 2*pi*k*n1_tl
+    // Second term accumulates in r7
+    auto const r4 = mpfr_values::multiply(const3548, k);  // r4 = -3.548*k
+    auto const r5 =
+        mpfr_values::multiply(const167, lambda);       // r5 = -0.167*lambda
+    auto const r6 = mpfr_values::add(r4, r5);          // r6 = r4 + r5
+    auto const r7 = mpfr_values::multiply(n3_31, r6);  // r7 = n3_31*r6
 
-  // Second term accumulates in r7
-  auto const r4        = mpfr_values::multiply(const3548, k);  // r4 = -3.548*k
-  auto const r5 =
-      mpfr_values::multiply(const167, lambda);       // r5 = -0.167*lambda
-  auto const r6 = mpfr_values::add(r4, r5);          // r6 = r4 + r5
-  auto const r7 = mpfr_values::multiply(n3_31, r6);  // r7 = n3_31*r6
+    // Third term accumulates in r11
+    auto const r8 = mpfr_values::multiply(const5355, k);  // r8 = -5.355*k
+    auto const r9 =
+        mpfr_values::multiply(const204, lambda);           // r9 = -0.204*lambda
+    auto const r10   = mpfr_values::add(r8, r9);           // r10 = r8+r9
+    auto const r11   = mpfr_values::multiply(n3_22, r10);  // r11 = n3_22*r10
 
-  // Third term accumulates in r11
-  auto const r8 = mpfr_values::multiply(const5355, k);  // r8 = -5.355*k
-  auto const r9 =
-      mpfr_values::multiply(const204, lambda);           // r9 = -0.204*lambda
-  auto const r10   = mpfr_values::add(r8, r9);           // r10 = r8+r9
-  auto const r11   = mpfr_values::multiply(n3_22, r10);  // r11 = n3_22*r10
+    // Result is r3+r7+r11
+    auto const r12   = mpfr_values::add(r3, r7);    // r12 = r3+r7
+    auto const total = mpfr_values::add(r11, r12);  // total = r11+r12
 
-  // Result is r3+r7+r11
-  auto const r12   = mpfr_values::add(r3, r7);    // r12 = r3+r7
-  auto const total = mpfr_values::add(r11, r12);  // total = r11+r12
+    return total;
+  }  // S3_bulk_action_alpha_one()
 
-  return total;
-}  // S3_bulk_action_alpha_one()
+  /// @brief Calculates the generalized S3 bulk action in terms of \f$\alpha\f$,
+  /// \f$k\f$, \f$\lambda\f$, \f$N_1^{TL}\f$, \f$N_3^{(3,1)}\f$, and
+  /// \f$N_3^{(2,2)}\f$.
+  ///
+  /// The formula is:
+  ///
+  /// \f{eqnarray*}{
+  /// S^{(3)} &=& 2\pi k\sqrt{\alpha}N_1^{TL} \\
+  /// &+& N_3^{(3,1)}\left[-3k\text{arcsinh}\left(\frac{1}{\sqrt{3}
+  /// \sqrt{4\alpha
+  /// +1}}\right)-3k\sqrt{\alpha}\text{arccos}\left(\frac{2\alpha+1}
+  /// {4\alpha+1}\right)-\frac{\lambda}{12}\sqrt{3\alpha+1}\right] \\
+  /// &+&
+  /// N_3^{(2,2)}\left[2k\text{arcsinh}\left(\frac{2\sqrt{2}\sqrt{2\alpha+1}}
+  /// {4\alpha +1}\right)-4k\sqrt{\alpha}\text{arccos}\left(\frac{-1}{4\alpha+1}
+  /// \right)-\frac{\lambda}{12}\sqrt{4\alpha +2}\right]\f}
+  ///
+  /// @param N1_TL  \f$N_1^{TL}\f$ is the number of timelike links
+  /// @param N3_31_13  \f$N_3^{(3,1)}\f$ is the number of (3,1) and (1,3)
+  /// simplices
+  /// @param N3_22  \f$N_3^{(2,2)}\f$ is the number of (2,2) simplices
+  /// @param Alpha  \f$\alpha\f$ is the timelike edge length
+  /// @param K      \f$k=\frac{1}{8\pi G_{Newton}}\f$
+  /// @param Lambda \f$\lambda=k*\Lambda\f$ where \f$\Lambda\f$ is the
+  ///                   Cosmological constant
+  /// @returns \f$S^{(3)}(\alpha)\f$ as a 256-bit MPFR value
+  /// @see [Regge calculus](../REFERENCES.md#regge-calculus)
+  /// @see [Three-dimensional CDT
+  /// action](../REFERENCES.md#three-dimensional-cdt-2001)
+  [[nodiscard]] inline auto S3_bulk_action(
+      Int_precision const N1_TL, Int_precision const N3_31_13,
+      Int_precision const N3_22, long double const Alpha, long double const K,
+      long double const Lambda) -> mpfr_values::Value
+  {
+    auto const parameters =
+        s3_action::make_physical_parameters(Alpha, K, Lambda);
 
-/// @brief Calculates the generalized S3 bulk action in terms of \f$\alpha\f$,
-/// \f$k\f$, \f$\lambda\f$, \f$N_1^{TL}\f$, \f$N_3^{(3,1)}\f$, and
-/// \f$N_3^{(2,2)}\f$.
-///
-/// The formula is:
-///
-/// \f{eqnarray*}{
-/// S^{(3)} &=& 2\pi k\sqrt{\alpha}N_1^{TL} \\
-/// &+& N_3^{(3,1)}\left[-3k\text{arcsinh}\left(\frac{1}{\sqrt{3}
-/// \sqrt{4\alpha +1}}\right)-3k\sqrt{\alpha}\text{arccos}\left(\frac{2\alpha+1}
-/// {4\alpha+1}\right)-\frac{\lambda}{12}\sqrt{3\alpha+1}\right] \\
-/// &+& N_3^{(2,2)}\left[2k\text{arcsinh}\left(\frac{2\sqrt{2}\sqrt{2\alpha+1}}
-/// {4\alpha +1}\right)-4k\sqrt{\alpha}\text{arccos}\left(\frac{-1}{4\alpha+1}
-/// \right)-\frac{\lambda}{12}\sqrt{4\alpha +2}\right]\f}
-///
-/// @param N1_TL  \f$N_1^{TL}\f$ is the number of timelike links
-/// @param N3_31_13  \f$N_3^{(3,1)}\f$ is the number of (3,1) and (1,3)
-/// simplices
-/// @param N3_22  \f$N_3^{(2,2)}\f$ is the number of (2,2) simplices
-/// @param Alpha  \f$\alpha\f$ is the timelike edge length
-/// @param K      \f$k=\frac{1}{8\pi G_{Newton}}\f$
-/// @param Lambda \f$\lambda=k*\Lambda\f$ where \f$\Lambda\f$ is the
-///                   Cosmological constant
-/// @returns \f$S^{(3)}(\alpha)\f$ as a 256-bit MPFR value
-/// @see [Regge calculus](../REFERENCES.md#regge-calculus)
-/// @see [Three-dimensional CDT
-/// action](../REFERENCES.md#three-dimensional-cdt-2001)
-[[nodiscard]] inline auto S3_bulk_action(
-    Int_precision const N1_TL, Int_precision const N3_31_13,
-    Int_precision const N3_22, long double const Alpha, long double const K,
-    long double const Lambda) -> mpfr_values::Value
-{
-  auto const parameters = s3_action::make_physical_parameters(Alpha, K, Lambda);
+    // Set input parameters and constants to MPFR equivalents
+    auto const n1_tl  = mpfr_values::from_integer(N1_TL);
+    auto const n3_31  = mpfr_values::from_integer(N3_31_13);
+    auto const n3_22  = mpfr_values::from_integer(N3_22);
+    auto const alpha  = mpfr_values::from_long_double(parameters.alpha);
+    auto const k      = mpfr_values::from_long_double(parameters.k);
+    auto const lambda = mpfr_values::from_long_double(parameters.lambda);
+    auto const two    = mpfr_values::from_integer(2);
+    auto const pi     = mpfr_values::pi();
+    auto const three  = mpfr_values::from_integer(3);
+    auto const four   = mpfr_values::from_integer(4);
+    auto const one    = mpfr_values::from_integer(1);
+    auto const twelve = mpfr_values::from_integer(12);
 
-  // Set input parameters and constants to MPFR equivalents
-  auto const n1_tl      = mpfr_values::from_integer(N1_TL);
-  auto const n3_31      = mpfr_values::from_integer(N3_31_13);
-  auto const n3_22      = mpfr_values::from_integer(N3_22);
-  auto const alpha      = mpfr_values::from_long_double(parameters.alpha);
-  auto const k          = mpfr_values::from_long_double(parameters.k);
-  auto const lambda     = mpfr_values::from_long_double(parameters.lambda);
-  auto const two        = mpfr_values::from_integer(2);
-  auto const pi         = mpfr_values::pi();
-  auto const three      = mpfr_values::from_integer(3);
-  auto const four       = mpfr_values::from_integer(4);
-  auto const one        = mpfr_values::from_integer(1);
-  auto const twelve     = mpfr_values::from_integer(12);
+    // First term accumulates in r5
+    auto const r1     = mpfr_values::multiply(two, pi);   // r1 = 2*pi
+    auto const r2     = mpfr_values::multiply(r1, k);     // r2 = 2*pi*k
+    auto const r3     = mpfr_values::square_root(alpha);  // r3 = sqrt(alpha)
+    auto const r4 =
+        mpfr_values::multiply(r3, r2);  // r4 = r3*r2 = 2*pi*k*sqrt(alpha)
+    auto const r5 = mpfr_values::multiply(r4, n1_tl);  // r5 = r4*n1_tl
 
-  // First term accumulates in r5
-  auto const r1         = mpfr_values::multiply(two, pi);   // r1 = 2*pi
-  auto const r2         = mpfr_values::multiply(r1, k);     // r2 = 2*pi*k
-  auto const r3         = mpfr_values::square_root(alpha);  // r3 = sqrt(alpha)
-  auto const r4 =
-      mpfr_values::multiply(r3, r2);  // r4 = r3*r2 = 2*pi*k*sqrt(alpha)
-  auto const r5 = mpfr_values::multiply(r4, n1_tl);  // r5 = r4*n1_tl
+    // Second term accumulates in r30
+    auto const r6 = mpfr_values::square_root(three);     // r6 = sqrt(3)
+    auto const r7 = mpfr_values::multiply(four, alpha);  // r7 = 4*alpha
+    auto const r8 = mpfr_values::add(one, r7);  // r8 = r7+1 = 4*alpha+1
+    auto const r9 =
+        mpfr_values::square_root(r8);  // r9 = sqrt(r8) = sqrt(4*alpha+1)
+    auto const r10 = mpfr_values::multiply(r6, r9);  // r10 = r6*r9
+    auto const r11 = mpfr_values::divide(one, r10);  // r11 = 1/r10
+    auto const r12 =
+        mpfr_values::inverse_hyperbolic_sine(r11);   // r12 = arcsinh(r11)
+    auto const r13 = mpfr_values::negate(three);     // r13 = -3
+    auto const r14 = mpfr_values::multiply(r13, k);  // r14 = r13*k = -3*k
+    // r15 = r14*r12 = -3*k*arcsinh(r11)
+    auto const r15 = mpfr_values::multiply(r14, r12);
 
-  // Second term accumulates in r30
-  auto const r6 = mpfr_values::square_root(three);     // r6 = sqrt(3)
-  auto const r7 = mpfr_values::multiply(four, alpha);  // r7 = 4*alpha
-  auto const r8 = mpfr_values::add(one, r7);           // r8 = r7+1 = 4*alpha+1
-  auto const r9 =
-      mpfr_values::square_root(r8);  // r9 = sqrt(r8) = sqrt(4*alpha+1)
-  auto const r10 = mpfr_values::multiply(r6, r9);  // r10 = r6*r9
-  auto const r11 = mpfr_values::divide(one, r10);  // r11 = 1/r10
-  auto const r12 =
-      mpfr_values::inverse_hyperbolic_sine(r11);   // r12 = arcsinh(r11)
-  auto const r13 = mpfr_values::negate(three);     // r13 = -3
-  auto const r14 = mpfr_values::multiply(r13, k);  // r14 = r13*k = -3*k
-  // r15 = r14*r12 = -3*k*arcsinh(r11)
-  auto const r15 = mpfr_values::multiply(r14, r12);
+    auto const r16 = mpfr_values::multiply(two, alpha);  // r16 = 2*alpha
+    auto const r17 = mpfr_values::add(r16, one);         // r17 = 2*alpha+1
+    auto const r18 =
+        mpfr_values::divide(r17, r8);  // r18 = (2*alpha+1)/(4*alpha+1)
+    auto const r19 = mpfr_values::arc_cosine(r18);    // r19 = arccos(r18)
+    auto const r20 = mpfr_values::multiply(r14, r3);  // r20 = -3*k*sqrt(alpha)
+    auto const r21 =
+        mpfr_values::multiply(r20, r19);  // r21 = -3*k*sqrt(alpha)*arccos(r18)
 
-  auto const r16 = mpfr_values::multiply(two, alpha);  // r16 = 2*alpha
-  auto const r17 = mpfr_values::add(r16, one);         // r17 = 2*alpha+1
-  auto const r18 =
-      mpfr_values::divide(r17, r8);  // r18 = (2*alpha+1)/(4*alpha+1)
-  auto const r19 = mpfr_values::arc_cosine(r18);    // r19 = arccos(r18)
-  auto const r20 = mpfr_values::multiply(r14, r3);  // r20 = -3*k*sqrt(alpha)
-  auto const r21 =
-      mpfr_values::multiply(r20, r19);  // r21 = -3*k*sqrt(alpha)*arccos(r18)
+    auto const r22 = mpfr_values::multiply(three, alpha);  // r22 = 3*alpha
+    auto const r23 = mpfr_values::add(r22, one);           // r23 = 3*alpha+1
+    auto const r24 = mpfr_values::square_root(r23);     // r24 = sqrt(3*alpha+1)
+    auto const r25 = mpfr_values::negate(lambda);       // r25 = -lambda
+    auto const r26 = mpfr_values::divide(r25, twelve);  // r26 = -lambda/12
+    auto const r27 =
+        mpfr_values::multiply(r26, r24);  // r27 = (-lambda/12)*sqrt(3*alpha+1)
 
-  auto const r22 = mpfr_values::multiply(three, alpha);  // r22 = 3*alpha
-  auto const r23 = mpfr_values::add(r22, one);           // r23 = 3*alpha+1
-  auto const r24 = mpfr_values::square_root(r23);     // r24 = sqrt(3*alpha+1)
-  auto const r25 = mpfr_values::negate(lambda);       // r25 = -lambda
-  auto const r26 = mpfr_values::divide(r25, twelve);  // r26 = -lambda/12
-  auto const r27 =
-      mpfr_values::multiply(r26, r24);  // r27 = (-lambda/12)*sqrt(3*alpha+1)
+    // Accumulate partial sums of second term
+    auto const r28 = mpfr_values::add(r15, r21);  // r28 = r15+r21
+    auto const r29 = mpfr_values::add(r28, r27);  // r29 = r28+r27
 
-  // Accumulate partial sums of second term
-  auto const r28 = mpfr_values::add(r15, r21);  // r28 = r15+r21
-  auto const r29 = mpfr_values::add(r28, r27);  // r29 = r28+r27
+    // Multiply by overall factor of n3_31
+    auto const r30 = mpfr_values::multiply(n3_31, r29);  // r30 = n3_31*r29
 
-  // Multiply by overall factor of n3_31
-  auto const r30 = mpfr_values::multiply(n3_31, r29);  // r30 = n3_31*r29
+    // Third term accumulates in r51
+    auto const r31 = mpfr_values::multiply(two, k);    // r31 = 2*k
+    auto const r32 = mpfr_values::square_root(two);    // r32 = sqrt(2)
+    auto const r33 = mpfr_values::multiply(two, r32);  // r33 = 2*sqrt(2)
+    auto const r34 = mpfr_values::square_root(r17);    // r34 = sqrt(2*alpha+1)
+    auto const r35 = mpfr_values::multiply(r33, r34);  // r35 = r33*r34
+    auto const r36 =
+        mpfr_values::divide(r35, r8);  // r36 = 2*sqrt(2)*sqrt(2*alpha+1)/
+                                       //       4*alpha+1
+    auto const r37 =
+        mpfr_values::inverse_hyperbolic_sine(r36);     // r37 = arcsinh(r36)
+    auto const r38 = mpfr_values::multiply(r31, r37);  // r38 = 2*k*arcsinh(r36)
 
-  // Third term accumulates in r51
-  auto const r31 = mpfr_values::multiply(two, k);    // r31 = 2*k
-  auto const r32 = mpfr_values::square_root(two);    // r32 = sqrt(2)
-  auto const r33 = mpfr_values::multiply(two, r32);  // r33 = 2*sqrt(2)
-  auto const r34 = mpfr_values::square_root(r17);    // r34 = sqrt(2*alpha+1)
-  auto const r35 = mpfr_values::multiply(r33, r34);  // r35 = r33*r34
-  auto const r36 =
-      mpfr_values::divide(r35, r8);  // r36 = 2*sqrt(2)*sqrt(2*alpha+1)/
-                                     //       4*alpha+1
-  auto const r37 =
-      mpfr_values::inverse_hyperbolic_sine(r36);     // r37 = arcsinh(r36)
-  auto const r38 = mpfr_values::multiply(r31, r37);  // r38 = 2*k*arcsinh(r36)
+    auto const r39 = mpfr_values::negate(one);        // r39 = -1
+    auto const r40 = mpfr_values::divide(r39, r8);    // r40 = -1/(4*alpha+1)
+    auto const r41 = mpfr_values::arc_cosine(r40);    // r41 = arccos(r40)
+    auto const r42 = mpfr_values::negate(four);       // r42 = -4
+    auto const r43 = mpfr_values::multiply(r42, k);   // r43 = -4*k
+    auto const r44 = mpfr_values::multiply(r43, r3);  // r44 = -4*k*sqrt(alpha)
+    auto const r45 =
+        mpfr_values::multiply(r44, r41);  // r45 = -4*k*sqrt(alpha)*arccos(r40)
 
-  auto const r39 = mpfr_values::negate(one);        // r39 = -1
-  auto const r40 = mpfr_values::divide(r39, r8);    // r40 = -1/(4*alpha+1)
-  auto const r41 = mpfr_values::arc_cosine(r40);    // r41 = arccos(r40)
-  auto const r42 = mpfr_values::negate(four);       // r42 = -4
-  auto const r43 = mpfr_values::multiply(r42, k);   // r43 = -4*k
-  auto const r44 = mpfr_values::multiply(r43, r3);  // r44 = -4*k*sqrt(alpha)
-  auto const r45 =
-      mpfr_values::multiply(r44, r41);  // r45 = -4*k*sqrt(alpha)*arccos(r40)
+    auto const r46 = mpfr_values::add(r7, two);      // r46 = 4*alpha+2
+    auto const r47 = mpfr_values::square_root(r46);  // r47 = sqrt(4*alpha+2)
+    auto const r48 =
+        mpfr_values::multiply(r26, r47);  // r48 = (-lambda/12)*sqrt(4*alpha+2)
 
-  auto const r46 = mpfr_values::add(r7, two);      // r46 = 4*alpha+2
-  auto const r47 = mpfr_values::square_root(r46);  // r47 = sqrt(4*alpha+2)
-  auto const r48 =
-      mpfr_values::multiply(r26, r47);  // r48 = (-lambda/12)*sqrt(4*alpha+2)
+    // Accumulate partial sums of third term
+    auto const r49   = mpfr_values::add(r38, r45);  // r49 = r38+r45
+    auto const r50   = mpfr_values::add(r49, r48);  // r50 = r49+r48
 
-  // Accumulate partial sums of third term
-  auto const r49   = mpfr_values::add(r38, r45);  // r49 = r38+r45
-  auto const r50   = mpfr_values::add(r49, r48);  // r50 = r49+r48
+    // Multiply by overall factor of n3_22
+    auto const r51   = mpfr_values::multiply(n3_22, r50);  // r51 = n3_22*r50
 
-  // Multiply by overall factor of n3_22
-  auto const r51   = mpfr_values::multiply(n3_22, r50);  // r51 = n3_22*r50
+    auto const r52   = mpfr_values::add(r5, r30);   // r52 = r5+r30
+    auto const total = mpfr_values::add(r51, r52);  // total = r51+r52
 
-  auto const r52   = mpfr_values::add(r5, r30);   // r52 = r5+r30
-  auto const total = mpfr_values::add(r51, r52);  // total = r51+r52
-
-  return total;
-}  // S3_bulk_action()
+    return total;
+  }  // S3_bulk_action()
 
 #pragma GCC diagnostic pop
+
+}  // namespace cdt::s3_action
 
 #endif  // INCLUDE_S3ACTION_HPP_

--- a/include/Settings.hpp
+++ b/include/Settings.hpp
@@ -16,44 +16,48 @@
 
 #include <cstdint>
 
-/// Results are converted to a CGAL multi-precision floating point number.
-/// Gmpzf itself is based on GMP (https://gmplib.org), as is MPFR.
-using Gmpzf         = CGAL::Gmpzf;
+namespace cdt
+{
+  /// Results are converted to a CGAL multi-precision floating point number.
+  /// Gmpzf itself is based on GMP (https://gmplib.org), as is MPFR.
+  using Gmpzf         = CGAL::Gmpzf;
 
-/// Sets the type of integer to use throughout the project.
-/// These are the base values read into the program or used in calculations.
-/// Casts to unsigned types are still necessary for certain library functions
-/// to work.
+  /// Sets the type of integer to use throughout the project.
+  /// These are the base values read into the program or used in calculations.
+  /// Casts to unsigned types are still necessary for certain library functions
+  /// to work.
 
-using Int_precision = std::int32_t;
+  using Int_precision = std::int32_t;
 
 #ifdef _WIN32
-#define __PRETTY_FUNCTION__ __FUNCSIG__
+#define CDT_PRETTY_FUNCTION __FUNCSIG__
+#else
+#define CDT_PRETTY_FUNCTION __PRETTY_FUNCTION__
 #endif
 
-// #define CGAL_LINKED_WITH_TBB
+  // #define CGAL_LINKED_WITH_TBB
 
-/// Correctly declare global constants
-/// See Jonathan Boccara's C++ Pitfalls, January 2021
+  /// Correctly declare global constants
+  /// See Jonathan Boccara's C++ Pitfalls, January 2021
 
-/// Sets the precision for <a href="http://www.mpfr.org">MPFR</a>.
-static inline Int_precision constexpr PRECISION  = 256;
+  /// Sets the precision for <a href="http://www.mpfr.org">MPFR</a>.
+  inline Int_precision constexpr PRECISION                             = 256;
 
-/// Default foliated triangulation spacings
-static inline double constexpr INITIAL_RADIUS    = 1.0;
-static inline double constexpr FOLIATION_SPACING = 1.0;
+  /// Default foliated triangulation spacings
+  inline double constexpr INITIAL_RADIUS                               = 1.0;
+  inline double constexpr FOLIATION_SPACING                            = 1.0;
 
-/// Sets epsilon values for floating point comparisons
-static inline double constexpr TOLERANCE         = 0.01;
+  /// Sets epsilon values for floating point comparisons
+  inline double constexpr TOLERANCE                                    = 0.01;
 
-/// Depends on INITIAL_RADIUS and RADIAL_FACTOR
-[[maybe_unused]] static inline Int_precision constexpr GV_BOUNDING_BOX_SIZE =
-    100;
+  /// Depends on INITIAL_RADIUS and RADIAL_FACTOR
+  [[maybe_unused]] inline Int_precision constexpr GV_BOUNDING_BOX_SIZE = 100;
 
-/// Aligns data for ease of access on 64-bit CPUs at the expense of padding
-static inline int constexpr ALIGNMENT_64_BIT = 64;
+  /// Aligns data for ease of access on 64-bit CPUs at the expense of padding
+  inline int constexpr ALIGNMENT_64_BIT                                = 64;
 
-/// Except when we only need 32 bits
-static inline int constexpr ALIGNMENT_32_BIT = 32;
+  /// Except when we only need 32 bits
+  inline int constexpr ALIGNMENT_32_BIT                                = 32;
+}  // namespace cdt
 
 #endif  // INCLUDE_SETTINGS_HPP_

--- a/include/Torus_d.hpp
+++ b/include/Torus_d.hpp
@@ -20,27 +20,31 @@
 
 #include <vector>
 
-using Kd        = CGAL::Cartesian_d<double>;
-using Point     = Kd::Point_d;
-using Creator_d = CGAL::Creator_uniform_d<std::vector<double>::iterator, Point>;
-
-/**
- * \brief Make a d-dimensional torus
- * \param t_points The container of points
- * \param t_number_of_points The number of points to insert
- * \param t_dimension The dimensionality of the torus
- */
-inline void make_d_cube(std::vector<Point>& t_points,
-                        std::size_t t_number_of_points, int t_dimension)
+namespace cdt::experimental::torus
 {
-  double constexpr size = 1.0;
+  using Kd    = CGAL::Cartesian_d<double>;
+  using Point = Kd::Point_d;
+  using Creator_d =
+      CGAL::Creator_uniform_d<std::vector<double>::iterator, Point>;
 
-  fmt::print("Generating {} grid points in {}D\n", t_number_of_points,
-             t_dimension);
+  /**
+   * \brief Make a d-dimensional torus
+   * \param t_points The container of points
+   * \param t_number_of_points The number of points to insert
+   * \param t_dimension The dimensionality of the torus
+   */
+  inline void make_d_cube(std::vector<Point>& t_points,
+                          std::size_t t_number_of_points, int t_dimension)
+  {
+    double constexpr size = 1.0;
 
-  t_points.reserve(t_number_of_points);
-  points_on_cube_grid_d(t_dimension, size, t_number_of_points,
-                        std::back_inserter(t_points), Creator_d(t_dimension));
-}
+    fmt::print("Generating {} grid points in {}D\n", t_number_of_points,
+               t_dimension);
+
+    t_points.reserve(t_number_of_points);
+    points_on_cube_grid_d(t_dimension, size, t_number_of_points,
+                          std::back_inserter(t_points), Creator_d(t_dimension));
+  }
+}  // namespace cdt::experimental::torus
 
 #endif  // INCLUDE_TORUS_D_HPP_

--- a/include/Triangulation_traits.hpp
+++ b/include/Triangulation_traits.hpp
@@ -19,42 +19,45 @@
 
 #include "Settings.hpp"
 
-template <int dimension>
-struct TriangulationTraits;
-
-template <>
-struct TriangulationTraits<3>
+namespace cdt::detail
 {
-  using Kernel = CGAL::Exact_predicates_inexact_constructions_kernel;
-  using Vertex_base =
-      CGAL::Triangulation_vertex_base_with_info_3<Int_precision, Kernel>;
-  using Cell_base =
-      CGAL::Triangulation_cell_base_with_info_3<Int_precision, Kernel>;
+  template <int dimension>
+  struct TriangulationTraits;
+
+  template <>
+  struct TriangulationTraits<3>
+  {
+    using Kernel = CGAL::Exact_predicates_inexact_constructions_kernel;
+    using Vertex_base =
+        CGAL::Triangulation_vertex_base_with_info_3<Int_precision, Kernel>;
+    using Cell_base =
+        CGAL::Triangulation_cell_base_with_info_3<Int_precision, Kernel>;
 #ifdef CGAL_LINKED_WITH_TBB
-  using Tds = CGAL::Triangulation_data_structure_3<Vertex_base, Cell_base,
-                                                   CGAL::Parallel_tag>;
+    using Tds = CGAL::Triangulation_data_structure_3<Vertex_base, Cell_base,
+                                                     CGAL::Parallel_tag>;
 #else
-  using Tds = CGAL::Triangulation_data_structure_3<Vertex_base, Cell_base>;
+    using Tds = CGAL::Triangulation_data_structure_3<Vertex_base, Cell_base>;
 #endif
-  using Delaunay      = CGAL::Delaunay_triangulation_3<Kernel, Tds>;
+    using Delaunay    = CGAL::Delaunay_triangulation_3<Kernel, Tds>;
 
-  using Cell_handle   = Delaunay::Cell_handle;
-  using Face_handle   = std::pair<Cell_handle, Int_precision>;
-  using Facet         = Delaunay::Facet;
-  using Edge_handle   = CGAL::Triple<Cell_handle, Int_precision, Int_precision>;
-  using Vertex_handle = Delaunay::Vertex_handle;
-  using Point         = Delaunay::Point;
-  using Causal_vertices  = std::vector<std::pair<Point, Int_precision>>;
+    using Cell_handle = Delaunay::Cell_handle;
+    using Face_handle = std::pair<Cell_handle, Int_precision>;
+    using Facet       = Delaunay::Facet;
+    using Edge_handle = CGAL::Triple<Cell_handle, Int_precision, Int_precision>;
+    using Vertex_handle    = Delaunay::Vertex_handle;
+    using Point            = Delaunay::Point;
+    using Causal_vertices  = std::vector<std::pair<Point, Int_precision>>;
 
-  /// @brief CGAL::squared_distance
-  /// See
-  /// https://doc.cgal.org/latest/Kernel_23/group__squared__distance__grp.html#ga1ff73525660a052564d33fbdd61a4f71
-  /// @returns Square of Euclidean distance between two geometric objects
-  using squared_distance = Kernel::Compute_squared_distance_3;
+    /// @brief CGAL::squared_distance
+    /// See
+    /// https://doc.cgal.org/latest/Kernel_23/group__squared__distance__grp.html#ga1ff73525660a052564d33fbdd61a4f71
+    /// @returns Square of Euclidean distance between two geometric objects
+    using squared_distance = Kernel::Compute_squared_distance_3;
 
-  using Spherical_points_generator = CGAL::Random_points_on_sphere_3<Point>;
+    using Spherical_points_generator = CGAL::Random_points_on_sphere_3<Point>;
 
-  static inline Point const ORIGIN_POINT = Point{0, 0, 0};
-};  // TriangulationTraits<3>
+    static inline Point const ORIGIN_POINT = Point{0, 0, 0};
+  };  // TriangulationTraits<3>
+}  // namespace cdt::detail
 
 #endif  // CDT_PLUSPLUS_TRIANGULATION_TRAITS_HPP

--- a/include/Utilities.hpp
+++ b/include/Utilities.hpp
@@ -63,28 +63,31 @@
 #include "Settings.hpp"
 #include "Version.hpp"
 
-enum class topology_type
+namespace cdt
 {
-  TOROIDAL,
-  SPHERICAL
-};
-
-/// @brief Convert topology_type to string output
-/// @param t_os The output stream
-/// @param t_topology The topology
-/// @returns An output string of the topology
-inline auto operator<<(std::ostream& t_os, topology_type const& t_topology)
-    -> std::ostream&
-{
-  switch (t_topology)
+  enum class topology_type
   {
-    case topology_type::SPHERICAL: return t_os << "spherical";
-    case topology_type::TOROIDAL: return t_os << "toroidal";
-    default: return t_os << "none";
-  }
-}  // operator<<
+    TOROIDAL,
+    SPHERICAL
+  };
 
-namespace utilities
+  /// @brief Convert topology_type to string output
+  /// @param t_os The output stream
+  /// @param t_topology The topology
+  /// @returns An output string of the topology
+  inline auto operator<<(std::ostream& t_os, topology_type const& t_topology)
+      -> std::ostream&
+  {
+    switch (t_topology)
+    {
+      case topology_type::SPHERICAL: return t_os << "spherical";
+      case topology_type::TOROIDAL: return t_os << "toroidal";
+      default: return t_os << "none";
+    }
+  }  // operator<<
+}  // namespace cdt
+
+namespace cdt::utilities
 {
   enum class Artifact_kind
   {
@@ -96,8 +99,8 @@ namespace utilities
   /// @brief Provenance recorded next to every stochastic triangulation.
   /// @details Checkpoints are deliberately snapshots rather than resumable
   /// simulation states: the payload does not serialize mutable RNG state.
-  /// Payload-derived counts, time bounds, and fingerprints are reconciled with
-  /// the serialized triangulation before publication. Callers remain
+  /// Payload-derived counts, time bounds, and fingerprints are reconciled
+  /// with the serialized triangulation before publication. Callers remain
   /// responsible for supplying truthful run configuration and RNG provenance.
   struct Reproducibility_metadata
   {
@@ -1362,7 +1365,8 @@ namespace utilities
   /// @brief  Generate useful filenames
   /// @param t_topology The topology type from the scoped enum topology_type
   /// @param t_dimension The dimensionality of the triangulation
-  /// @param t_number_of_simplices The number of simplices in the triangulation
+  /// @param t_number_of_simplices The number of simplices in the
+  /// triangulation
   /// @param t_number_of_timeslices The number of time foliations
   /// @param t_initial_radius The radius of the first foliation t=1
   /// @param t_foliation_spacing The spacing between foliations
@@ -1678,8 +1682,8 @@ namespace utilities
                                t_max_timeslice);
   }  // generate_random_timeslice()
 
-  /// @brief Generate random real numbers by calling generate_random, preserves
-  /// template argument deduction
+  /// @brief Generate random real numbers by calling generate_random,
+  /// preserves template argument deduction
   template <std::uniform_random_bit_generator Generator,
             typename FloatingPointType>
   [[nodiscard]] auto generate_random_real(Generator&        generator,
@@ -1825,7 +1829,8 @@ namespace utilities
   /// -# Debug, which logs *Debug* and below to logs/debug-log.txt
   /// -# Trace, which logs everything to logs/trace-log.txt
   ///
-  /// If an exception is thrown, then the default global console logger is used.
+  /// If an exception is thrown, then the default global console logger is
+  /// used.
   inline void create_logger()
   try
   {
@@ -1887,5 +1892,5 @@ namespace utilities
     stream << t_topology;
     return stream.str();
   }  // topology_to_str
-}  // namespace utilities
+}  // namespace cdt::utilities
 #endif  // INCLUDE_UTILITIES_HPP_

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -77,19 +77,25 @@ lcov \
   --capture \
   --directory "${cmake_build_dir}" \
   --gcov-tool "${gcov_tool}" \
+  --no-function-coverage \
   --rc branch_coverage=1 \
   --output-file "${raw_coverage_file}"
 lcov \
   --extract "${raw_coverage_file}" \
   "${repo_root}/include/*" \
   "${repo_root}/src/*" \
+  --no-function-coverage \
   --rc branch_coverage=1 \
   --output-file "${coverage_file}"
 genhtml \
   --branch-coverage \
+  --no-function-coverage \
   --output-directory "${html_dir}" \
   "${coverage_file}"
-lcov --list "${coverage_file}" --rc branch_coverage=1
+lcov \
+  --list "${coverage_file}" \
+  --no-function-coverage \
+  --rc branch_coverage=1
 rm -f -- "${raw_coverage_file}"
 
 if [[ "${test_status}" -ne 0 ]]; then

--- a/scripts/pkgx-env.sh
+++ b/scripts/pkgx-env.sh
@@ -5,6 +5,8 @@
 if [[ -n "${BASH_VERSION:-}" ]]; then
   script_file="${BASH_SOURCE[0]}"
 elif [[ -n "${ZSH_VERSION:-}" ]]; then
+  # Intentional Zsh expansion that resolves the sourced script's path.
+  # shellcheck disable=SC2296
   script_file="${(%):-%x}"
 else
   printf 'pkgx-env.sh requires Bash or Zsh.\n' >&2

--- a/scripts/pkgx-env.sh
+++ b/scripts/pkgx-env.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+# Source this file from a shell or IDE environment-file setting.
+if [[ -n "${BASH_VERSION:-}" ]]; then
+  script_file="${BASH_SOURCE[0]}"
+elif [[ -n "${ZSH_VERSION:-}" ]]; then
+  script_file="${(%):-%x}"
+else
+  printf 'pkgx-env.sh requires Bash or Zsh.\n' >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+script_dir="$(cd -- "$(dirname -- "${script_file}")" && pwd -P)"
+repo_root="$(cd -- "${script_dir}/.." && pwd -P)"
+
+if ! pkgx_environment="$(pkgx \
+  +freedesktop.org/pkg-config@0.29.2 \
+  +gnu.org/m4@1.4.21 \
+  +gnu.org/autoconf@2.73.0 \
+  +gnu.org/autoconf-archive@2024.10.16 \
+  +gnu.org/automake@1.18.1 \
+  +gnu.org/libtool@2.5.4 \
+  +gnu.org/texinfo@7.3.0)"; then
+  printf 'Unable to resolve the pkgx build environment.\n' >&2
+  unset pkgx_environment repo_root script_dir script_file
+  return 1 2>/dev/null || exit 1
+fi
+
+case "$-" in
+  *a*) had_allexport=1 ;;
+  *) had_allexport=0; set -a ;;
+esac
+eval "${pkgx_environment}"
+if [[ "${had_allexport}" == 0 ]]; then
+  set +a
+fi
+
+# Keep pkgx-provided build tools on PATH without exposing their transitive
+# headers and libraries to compiler detection or vcpkg dependency builds.
+unset CMAKE_PREFIX_PATH
+unset CPATH
+unset C_INCLUDE_PATH
+unset CPLUS_INCLUDE_PATH
+unset CC
+unset CFLAGS
+unset CPPFLAGS
+unset CXX
+unset CXXFLAGS
+unset LDFLAGS
+unset LIBRARY_PATH
+unset PKG_CONFIG_PATH
+
+if [[ "$(uname -s)" == "Darwin" ]] && command -v xcode-select >/dev/null && command -v xcrun >/dev/null; then
+  unset DEVELOPER_DIR
+  DEVELOPER_DIR="$(xcode-select -p)"
+  SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
+  CC=/usr/bin/cc
+  CXX=/usr/bin/c++
+  unset ARCHFLAGS
+  unset MACOSX_DEPLOYMENT_TARGET
+  export CC CXX DEVELOPER_DIR SDKROOT
+fi
+
+export VCPKG_ROOT="${repo_root}/.cache/vcpkg"
+
+unset had_allexport pkgx_environment repo_root script_dir script_file

--- a/src/cdt-viewer.cpp
+++ b/src/cdt-viewer.cpp
@@ -16,6 +16,7 @@ Copyright © 2022 Adam Getchell
 #include "Utilities.hpp"
 #include "Version.hpp"
 
+using namespace cdt;
 namespace po = boost::program_options;
 
 static auto constexpr USAGE =

--- a/src/cdt.cpp
+++ b/src/cdt.cpp
@@ -22,6 +22,7 @@
 
 using Timer = CGAL::Real_timer;
 
+using namespace cdt;
 using namespace std;
 namespace po = boost::program_options;
 

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -15,6 +15,7 @@
 #include "Runtime_config.hpp"
 #include "Version.hpp"
 
+using namespace cdt;
 using namespace std;
 namespace po = boost::program_options;
 

--- a/tests/Apply_move_test.cpp
+++ b/tests/Apply_move_test.cpp
@@ -19,6 +19,7 @@
 
 #include "Ergodic_moves_3.hpp"
 
+using namespace cdt;
 using namespace std;
 using namespace manifolds;
 
@@ -74,7 +75,7 @@ namespace
   {
     CHECK(before.is_correct());
     CHECK(after.is_correct());
-    CHECK(ergodic_moves::check_move(before, after, move));
+    CHECK(ergodic_moves::detail::check_move(before, after, move));
   }
 }  // namespace
 

--- a/tests/Bistellar_flip_test.cpp
+++ b/tests/Bistellar_flip_test.cpp
@@ -19,9 +19,11 @@
 
 #include "Ergodic_moves_3.hpp"
 
+using namespace cdt;
 using namespace std;
 using namespace manifolds;
 using namespace ergodic_moves;
+using namespace ergodic_moves::detail;
 
 namespace
 {
@@ -289,12 +291,12 @@ SCENARIO("Test edge cases and error conditions for bistellar flip" *
 
       THEN("Incident-cell lookup should reject them")
       {
-        CHECK_FALSE(
-            get_incident_cells(triangulation, negative_index_edge).has_value());
-        CHECK_FALSE(
-            get_incident_cells(triangulation, out_of_range_edge).has_value());
-        CHECK_FALSE(
-            get_incident_cells(triangulation, repeated_index_edge).has_value());
+        CHECK_FALSE(incident_cells_from_edge(triangulation, negative_index_edge)
+                        .has_value());
+        CHECK_FALSE(incident_cells_from_edge(triangulation, out_of_range_edge)
+                        .has_value());
+        CHECK_FALSE(incident_cells_from_edge(triangulation, repeated_index_edge)
+                        .has_value());
       }
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,66 @@ target_link_libraries(
   CDT_random_header_compile_contract
   PRIVATE project_options project_warnings)
 
+# Compile a minimal downstream translation unit without namespace imports or
+# test-only access to implementation helpers.
+add_library(CDT_public_api_compile_contract OBJECT Public_api_consumer.cpp)
+target_link_libraries(
+  CDT_public_api_compile_contract
+  PRIVATE project_options
+          project_warnings
+          date::date-tz
+          fmt::fmt-header-only
+          spdlog::spdlog_header_only
+          TBB::tbb
+          CGAL::CGAL)
+
+# Compile every supported header as the first include in an independent
+# translation unit. Experimental archival headers are not part of this target.
+# This catches include-order dependencies and header-local ODR/linkage mistakes
+# at the downstream boundary.
+set(
+  cdt_supported_headers
+  Apply_move.hpp
+  Ergodic_moves_3.hpp
+  Foliated_triangulation.hpp
+  Formatters.hpp
+  Geometry.hpp
+  Manifold.hpp
+  Metropolis.hpp
+  Move_always.hpp
+  Move_command.hpp
+  Move_strategy.hpp
+  Move_tracker.hpp
+  Mpfr_value.hpp
+  Random.hpp
+  Runtime_config.hpp
+  S3Action.hpp
+  Settings.hpp
+  Triangulation_traits.hpp
+  Utilities.hpp)
+set(cdt_header_contract_sources)
+foreach(header IN LISTS cdt_supported_headers)
+  string(MAKE_C_IDENTIFIER "${header}" header_id)
+  set(source "${CMAKE_CURRENT_BINARY_DIR}/header_${header_id}.cpp")
+  file(GENERATE OUTPUT "${source}" CONTENT "#include \"${header}\"\n")
+  list(APPEND cdt_header_contract_sources "${source}")
+endforeach()
+set(cdt_header_contract_main
+    "${CMAKE_CURRENT_BINARY_DIR}/header_contract_main.cpp")
+file(GENERATE OUTPUT "${cdt_header_contract_main}"
+     CONTENT "int main() { return 0; }\n")
+add_executable(CDT_header_compile_contracts ${cdt_header_contract_sources}
+                                            "${cdt_header_contract_main}")
+target_link_libraries(
+  CDT_header_compile_contracts
+  PRIVATE project_options
+          project_warnings
+          date::date-tz
+          fmt::fmt-header-only
+          spdlog::spdlog_header_only
+          TBB::tbb
+          CGAL::CGAL)
+
 # Keep the issue #105 before/after diagnostic buildable without registering it
 # as a correctness test. Run it through `just benchmark-rng`.
 add_executable(CDT_rng_benchmark Random_benchmark.cpp)

--- a/tests/Ergodic_moves_3_audit_test.cpp
+++ b/tests/Ergodic_moves_3_audit_test.cpp
@@ -25,6 +25,8 @@
 
 #include "Ergodic_moves_3.hpp"
 
+using namespace cdt;
+
 namespace
 {
   using Manifold      = manifolds::Manifold_3;
@@ -683,7 +685,7 @@ SCENARIO("CDT move rejection is causal and failure-atomic" *
         foliated_triangulations::collect_cells<3>(triangulation),
         Cell_type::TWO_TWO);
     REQUIRE_EQ(two_two.size(), 1);
-    REQUIRE(ergodic_moves::try_23_move(triangulation, two_two.front()));
+    REQUIRE(ergodic_moves::detail::try_23_move(triangulation, two_two.front()));
     assign_independent_cell_metadata(triangulation);
     auto const inverse_edge = find_inverse_32_edge(triangulation);
     REQUIRE(inverse_edge.has_value());
@@ -721,7 +723,8 @@ SCENARIO("CDT move rejection is causal and failure-atomic" *
 
     WHEN("the CDT (3,2) helper checks the site")
     {
-      CHECK_FALSE(ergodic_moves::try_32_move(triangulation, *inverse_edge));
+      CHECK_FALSE(
+          ergodic_moves::detail::try_32_move(triangulation, *inverse_edge));
       THEN("it rejects before CGAL can create an acausal tetrahedron")
       { CHECK_EQ(canonical_triangulation(triangulation), before); }
     }
@@ -748,7 +751,7 @@ SCENARIO("CDT move rejection is causal and failure-atomic" *
     auto       move_32_cells = foliated_triangulations::filter_cells<3>(
         foliated_triangulations::collect_cells<3>(move_32), Cell_type::TWO_TWO);
     REQUIRE_EQ(move_32_cells.size(), 1);
-    REQUIRE(ergodic_moves::try_23_move(move_32, move_32_cells.front()));
+    REQUIRE(ergodic_moves::detail::try_23_move(move_32, move_32_cells.front()));
     assign_independent_cell_metadata(move_32);
     auto const inverse_edge = find_inverse_32_edge(move_32);
     REQUIRE(inverse_edge.has_value());
@@ -773,7 +776,7 @@ SCENARIO("CDT move rejection is causal and failure-atomic" *
     auto vertices_62 = foliated_triangulations::collect_vertices<3>(move_62);
     auto const candidate_62 =
         std::ranges::find_if(vertices_62, [&](auto const& vertex) {
-          return ergodic_moves::is_62_movable(move_62, vertex);
+          return ergodic_moves::detail::is_62_movable(move_62, vertex);
         });
     REQUIRE(candidate_62 != vertices_62.end());
     ergodic_moves::Cell_container incident_62;
@@ -793,11 +796,13 @@ SCENARIO("CDT move rejection is causal and failure-atomic" *
 
     WHEN("the corresponding cavity selectors inspect the sites")
     {
-      CHECK_FALSE(ergodic_moves::try_23_move(move_23, two_two.front()));
-      CHECK_FALSE(ergodic_moves::try_32_move(move_32, *inverse_edge));
-      CHECK_FALSE(ergodic_moves::find_adjacent_31_cell(one_three.front()));
-      CHECK_FALSE(ergodic_moves::is_62_movable(move_62, *candidate_62));
-      CHECK_FALSE(ergodic_moves::find_bistellar_flip_location(move_44, *pivot));
+      CHECK_FALSE(ergodic_moves::detail::try_23_move(move_23, two_two.front()));
+      CHECK_FALSE(ergodic_moves::detail::try_32_move(move_32, *inverse_edge));
+      CHECK_FALSE(
+          ergodic_moves::detail::find_adjacent_31_cell(one_three.front()));
+      CHECK_FALSE(ergodic_moves::detail::is_62_movable(move_62, *candidate_62));
+      CHECK_FALSE(
+          ergodic_moves::detail::find_bistellar_flip_location(move_44, *pivot));
       THEN("no topology is mutated")
       {
         CHECK_EQ(canonical_triangulation(move_23), before_23);
@@ -822,7 +827,8 @@ SCENARIO("CDT move rejection is causal and failure-atomic" *
 
     WHEN("the (2,3) selector checks the now-acausal tetrahedron")
     {
-      CHECK_FALSE(ergodic_moves::try_23_move(triangulation, two_two.front()));
+      CHECK_FALSE(
+          ergodic_moves::detail::try_23_move(triangulation, two_two.front()));
       THEN("the invalid site is rejected without mutation")
       { CHECK_EQ(canonical_triangulation(triangulation), before); }
     }
@@ -867,7 +873,7 @@ SCENARIO("CDT move rejection is causal and failure-atomic" *
     auto       vertices = foliated_triangulations::collect_vertices<3>(source);
     auto const candidate =
         std::ranges::find_if(vertices, [&](auto const& vertex) {
-          return ergodic_moves::is_62_movable(source, vertex);
+          return ergodic_moves::detail::is_62_movable(source, vertex);
         });
     REQUIRE(candidate != vertices.end());
     auto const  source_counts = direct_counts(source);
@@ -989,12 +995,13 @@ SCENARIO("CDT move rejection is causal and failure-atomic" *
     auto const        before = canonical_triangulation(triangulation);
     WHEN("the checked edge helpers receive them")
     {
-      CHECK_FALSE(ergodic_moves::get_incident_cells(triangulation, malformed));
-      CHECK_FALSE(
-          ergodic_moves::get_incident_cells(triangulation, *boundary_edge));
-      CHECK_FALSE(ergodic_moves::find_bistellar_flip_location(triangulation,
-                                                              *foreign_pivot));
-      CHECK_FALSE(ergodic_moves::try_32_move(triangulation, malformed));
+      CHECK_FALSE(ergodic_moves::detail::incident_cells_from_edge(triangulation,
+                                                                  malformed));
+      CHECK_FALSE(ergodic_moves::detail::incident_cells_from_edge(
+          triangulation, *boundary_edge));
+      CHECK_FALSE(ergodic_moves::detail::find_bistellar_flip_location(
+          triangulation, *foreign_pivot));
+      CHECK_FALSE(ergodic_moves::detail::try_32_move(triangulation, malformed));
       THEN("the triangulation remains unchanged")
       { CHECK_EQ(canonical_triangulation(triangulation), before); }
     }
@@ -1022,6 +1029,6 @@ TEST_CASE("Move validation rejects exact configuration-state drift" *
                                                        before.delaunay_snapshot(), -0.0, before.foliation_spacing()}
   };
   REQUIRE(after.is_correct());
-  CHECK_FALSE(ergodic_moves::check_move(before, after,
-                                        move_tracker::move_type::FOUR_FOUR));
+  CHECK_FALSE(ergodic_moves::detail::check_move(
+      before, after, move_tracker::move_type::FOUR_FOUR));
 }

--- a/tests/Ergodic_moves_3_test.cpp
+++ b/tests/Ergodic_moves_3_test.cpp
@@ -15,6 +15,7 @@
 
 #include <numbers>
 
+using namespace cdt;
 using namespace std;
 using namespace manifolds;
 
@@ -148,8 +149,8 @@ SCENARIO("Use check_move to validate successful move" *
       {
         check_geometry_delta(manifold_before, manifold,
                              move_tracker::move_type::TWO_THREE);
-        CHECK(ergodic_moves::check_move(manifold_before, manifold,
-                                        move_tracker::move_type::TWO_THREE));
+        CHECK(ergodic_moves::detail::check_move(
+            manifold_before, manifold, move_tracker::move_type::TWO_THREE));
       }
     }
   }
@@ -205,8 +206,8 @@ SCENARIO(
       {
         check_geometry_delta(manifold_before, manifold,
                              move_tracker::move_type::TWO_THREE);
-        CHECK(ergodic_moves::check_move(manifold_before, manifold,
-                                        move_tracker::move_type::TWO_THREE));
+        CHECK(ergodic_moves::detail::check_move(
+            manifold_before, manifold, move_tracker::move_type::TWO_THREE));
         // Manual check
         REQUIRE(manifold.is_correct());
         CHECK_EQ(manifold.vertices(), 5);
@@ -263,8 +264,8 @@ SCENARIO(
       {
         check_geometry_delta(manifold_before, manifold,
                              move_tracker::move_type::THREE_TWO);
-        CHECK(ergodic_moves::check_move(manifold_before, manifold,
-                                        move_tracker::move_type::THREE_TWO));
+        CHECK(ergodic_moves::detail::check_move(
+            manifold_before, manifold, move_tracker::move_type::THREE_TWO));
         // Manual check
         REQUIRE(manifold.is_correct());
         CHECK_EQ(manifold.vertices(), 5);
@@ -343,8 +344,8 @@ SCENARIO(
         {
           check_geometry_delta(manifold_before, manifold,
                                move_tracker::move_type::TWO_SIX);
-          CHECK(ergodic_moves::check_move(manifold_before, manifold,
-                                          move_tracker::move_type::TWO_SIX));
+          CHECK(ergodic_moves::detail::check_move(
+              manifold_before, manifold, move_tracker::move_type::TWO_SIX));
           // Manual check
           REQUIRE(manifold.is_correct());
           CHECK_EQ(manifold.vertices(), 6);  // +1 vertex
@@ -412,8 +413,8 @@ SCENARIO(
           check_geometry_delta(manifold_before, manifold,
                                move_tracker::move_type::SIX_TWO);
           // Check the move
-          CHECK(ergodic_moves::check_move(manifold_before, manifold,
-                                          move_tracker::move_type::SIX_TWO));
+          CHECK(ergodic_moves::detail::check_move(
+              manifold_before, manifold, move_tracker::move_type::SIX_TWO));
           // Manual check
           REQUIRE(manifold.is_correct());
           CHECK(manifold.is_foliated());
@@ -503,8 +504,8 @@ SCENARIO("Perform ergodic moves on the minimal manifold necessary (4,4) moves" *
           check_geometry_delta(manifold_before, manifold,
                                move_tracker::move_type::FOUR_FOUR);
           // Check the move
-          CHECK(ergodic_moves::check_move(manifold_before, manifold,
-                                          move_tracker::move_type::FOUR_FOUR));
+          CHECK(ergodic_moves::detail::check_move(
+              manifold_before, manifold, move_tracker::move_type::FOUR_FOUR));
           CHECK_EQ(manifold.initial_radius(), manifold_before.initial_radius());
           CHECK_EQ(manifold.foliation_spacing(),
                    manifold_before.foliation_spacing());
@@ -541,7 +542,8 @@ SCENARIO("Test convenience functions needed for bistellar flip" *
     }
     WHEN("We find the pivot edge in the triangulation")
     {
-      auto pivot_edge = ergodic_moves::find_pivot_edge(triangulation, edges);
+      auto pivot_edge =
+          ergodic_moves::detail::find_pivot_edge(triangulation, edges);
       REQUIRE_MESSAGE(pivot_edge, "No pivot edge found.");
 
       auto Contains = [&vertices](Point_t<3> point) {
@@ -552,7 +554,7 @@ SCENARIO("Test convenience functions needed for bistellar flip" *
 
       if (pivot_edge)
       {
-        auto incident_cells = ergodic_moves::get_incident_cells(
+        auto incident_cells = ergodic_moves::detail::incident_cells_from_edge(
             triangulation, pivot_edge.value());
         REQUIRE_MESSAGE(incident_cells, "No incident cells found.");
         THEN("We have a pivot edge")
@@ -576,7 +578,7 @@ SCENARIO("Test convenience functions needed for bistellar flip" *
           AND_THEN("We can obtain the vertices from the incident cells")
           {
             auto incident_vertices =
-                ergodic_moves::get_vertices(incident_cells.value());
+                ergodic_moves::detail::get_vertices(incident_cells.value());
             REQUIRE_EQ(incident_vertices.size(), 6);
           }
         }
@@ -672,7 +674,8 @@ SCENARIO("Perform bistellar flip on Delaunay triangulation" *
         auto top    = triangulation.insert(Point_t<3>{0, 0, 2});
         auto bottom = triangulation.insert(Point_t<3>{0, 0, 0});
         auto edges  = foliated_triangulations::collect_edges<3>(triangulation);
-        auto pivot_edge = ergodic_moves::find_pivot_edge(triangulation, edges);
+        auto pivot_edge =
+            ergodic_moves::detail::find_pivot_edge(triangulation, edges);
         REQUIRE_MESSAGE(pivot_edge, "No pivot edge found.");
 
         // Check this didn't actually change vertices in the triangulation
@@ -680,7 +683,7 @@ SCENARIO("Perform bistellar flip on Delaunay triangulation" *
 
         if (pivot_edge)
         {
-          auto flipped_triangulation = ergodic_moves::bistellar_flip(
+          auto flipped_triangulation = ergodic_moves::detail::bistellar_flip(
               triangulation, pivot_edge.value(), top, bottom);
 
           REQUIRE_MESSAGE(flipped_triangulation, "Bistellar flip failed.");

--- a/tests/Foliated_triangulation_test.cpp
+++ b/tests/Foliated_triangulation_test.cpp
@@ -17,6 +17,7 @@
 #include <type_traits>
 #include <utility>
 
+using namespace cdt;
 using namespace std;
 using namespace foliated_triangulations;
 

--- a/tests/Function_ref_test.cpp
+++ b/tests/Function_ref_test.cpp
@@ -18,6 +18,7 @@
 
 #include "Ergodic_moves_3.hpp"
 
+using namespace cdt;
 using namespace std;
 using namespace manifolds;
 
@@ -79,8 +80,8 @@ SCENARIO("Complex lambda operations" * doctest::test_suite("function_ref"))
         cdt::Random random{92};
         CAPTURE(random.seed());
         auto result = move23(manifold, random);
-        CHECK(ergodic_moves::check_move(manifold_before, result,
-                                        move_tracker::move_type::TWO_THREE));
+        CHECK(ergodic_moves::detail::check_move(
+            manifold_before, result, move_tracker::move_type::TWO_THREE));
       }
     }
   }
@@ -113,8 +114,9 @@ SCENARIO("Function_ref operations" * doctest::test_suite("function_ref"))
       REQUIRE(result.has_value());
       THEN("The move from the function_ref is correct.")
       {
-        CHECK(ergodic_moves::check_move(manifold_before, result.value(),
-                                        move_tracker::move_type::TWO_THREE));
+        CHECK(ergodic_moves::detail::check_move(
+            manifold_before, result.value(),
+            move_tracker::move_type::TWO_THREE));
       }
     }
   }
@@ -137,8 +139,8 @@ SCENARIO("Function_ref operations" * doctest::test_suite("function_ref"))
           "The move stored in the lambda invoked by the function_ref is "
           "correct.")
       {
-        CHECK(ergodic_moves::check_move(manifold_before, result,
-                                        move_tracker::move_type::TWO_THREE));
+        CHECK(ergodic_moves::detail::check_move(
+            manifold_before, result, move_tracker::move_type::TWO_THREE));
       }
     }
   }

--- a/tests/Geometry_test.cpp
+++ b/tests/Geometry_test.cpp
@@ -14,6 +14,7 @@
 
 #include <type_traits>
 
+using namespace cdt;
 using namespace std;
 using namespace foliated_triangulations;
 

--- a/tests/Manifold_test.cpp
+++ b/tests/Manifold_test.cpp
@@ -16,6 +16,7 @@
 #include <type_traits>
 #include <utility>
 
+using namespace cdt;
 using namespace std;
 using namespace manifolds;
 

--- a/tests/Metropolis_test.cpp
+++ b/tests/Metropolis_test.cpp
@@ -21,6 +21,7 @@
 #include <type_traits>
 #include <vector>
 
+using namespace cdt;
 using namespace std;
 using namespace manifolds;
 
@@ -438,7 +439,7 @@ SCENARIO("The (6,2) proposal uses the caller-owned generator throughout" *
         auto const        selected =
             ergodic_moves::detail::random_element(vertices, selector);
         if (!selected ||
-            !ergodic_moves::is_62_movable(triangulation, *selected))
+            !ergodic_moves::detail::is_62_movable(triangulation, *selected))
         {
           continue;
         }

--- a/tests/Move_always_test.cpp
+++ b/tests/Move_always_test.cpp
@@ -14,6 +14,7 @@
 
 #include <type_traits>
 
+using namespace cdt;
 using namespace std;
 using namespace manifolds;
 

--- a/tests/Move_command_test.cpp
+++ b/tests/Move_command_test.cpp
@@ -31,6 +31,57 @@ namespace
   using VertexState = std::tuple<double, double, double, Int_precision>;
   using CellState   = std::pair<std::array<VertexState, 4>, Int_precision>;
 
+  struct ExpectedGeometryDelta
+  {
+    Int_precision n3;
+    Int_precision n3_31;
+    Int_precision n3_13;
+    Int_precision n3_31_13;
+    Int_precision n3_22;
+    Int_precision n2;
+    Int_precision n1;
+    Int_precision n1_tl;
+    Int_precision n1_sl;
+    Int_precision n0;
+  };
+
+  [[nodiscard]] auto constexpr expected_geometry_delta(
+      move_tracker::move_type const move) -> ExpectedGeometryDelta
+  {
+    using enum move_tracker::move_type;
+    switch (move)
+    {
+      case TWO_THREE: return {1, 0, 0, 0, 1, 2, 1, 1, 0, 0};
+      case THREE_TWO: return {-1, 0, 0, 0, -1, -2, -1, -1, 0, 0};
+      case TWO_SIX: return {4, 2, 2, 4, 0, 8, 5, 2, 3, 1};
+      case SIX_TWO: return {-4, -2, -2, -4, 0, -8, -5, -2, -3, -1};
+      case FOUR_FOUR: return {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    }
+    return {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  }
+
+  void check_successful_move_outcome(Manifold_3 const&             before,
+                                     Manifold_3 const&             after,
+                                     move_tracker::move_type const move)
+  {
+    auto const expected = expected_geometry_delta(move);
+    CHECK(after.is_correct());
+    CHECK_EQ(after.initial_radius(), before.initial_radius());
+    CHECK_EQ(after.foliation_spacing(), before.foliation_spacing());
+    CHECK_EQ(after.N3() - before.N3(), expected.n3);
+    CHECK_EQ(after.N3_31() - before.N3_31(), expected.n3_31);
+    CHECK_EQ(after.N3_13() - before.N3_13(), expected.n3_13);
+    CHECK_EQ(after.N3_31_13() - before.N3_31_13(), expected.n3_31_13);
+    CHECK_EQ(after.N3_22() - before.N3_22(), expected.n3_22);
+    CHECK_EQ(after.N2() - before.N2(), expected.n2);
+    CHECK_EQ(after.N1() - before.N1(), expected.n1);
+    CHECK_EQ(after.N1_TL() - before.N1_TL(), expected.n1_tl);
+    CHECK_EQ(after.N1_SL() - before.N1_SL(), expected.n1_sl);
+    CHECK_EQ(after.N0() - before.N0(), expected.n0);
+    CHECK_EQ(after.max_time(), before.max_time());
+    CHECK_EQ(after.min_time(), before.min_time());
+  }
+
   auto vertex_state(Vertex_handle_t<3> const& vertex) -> VertexState
   {
     auto const& point = vertex->point();
@@ -117,7 +168,7 @@ namespace
     if (succeeded == 1)
     {
       CHECK_EQ(result.simplices(), before.simplices() + cell_delta);
-      CHECK(ergodic_moves::detail::check_move(before, result, move));
+      check_successful_move_outcome(before, result, move);
     }
     else
     {
@@ -195,8 +246,9 @@ SCENARIO("Invoking a move with a function pointer" *
         cdt::Random random{92};
         CAPTURE(random.seed());
         auto result = move23(manifold, random);
-        CHECK(ergodic_moves::detail::check_move(
-            manifold, result.value(), move_tracker::move_type::TWO_THREE));
+        REQUIRE(result.has_value());
+        check_successful_move_outcome(manifold, *result,
+                                      move_tracker::move_type::TWO_THREE);
       }
     }
   }
@@ -222,8 +274,8 @@ SCENARIO("Invoking a move with a lambda" * doctest::test_suite("move_command"))
         cdt::Random random{92};
         CAPTURE(random.seed());
         auto result = move23(manifold, random);
-        CHECK(ergodic_moves::detail::check_move(
-            manifold, result, move_tracker::move_type::TWO_THREE));
+        check_successful_move_outcome(manifold, result,
+                                      move_tracker::move_type::TWO_THREE);
       }
     }
   }
@@ -247,8 +299,9 @@ SCENARIO("Invoking a move with apply_move and a function pointer" *
         cdt::Random random{92};
         CAPTURE(random.seed());
         auto result = apply_move(manifold, move, random);
-        CHECK(ergodic_moves::detail::check_move(
-            manifold, result.value(), move_tracker::move_type::TWO_THREE));
+        REQUIRE(result.has_value());
+        check_successful_move_outcome(manifold, *result,
+                                      move_tracker::move_type::TWO_THREE);
       }
     }
   }

--- a/tests/Move_command_test.cpp
+++ b/tests/Move_command_test.cpp
@@ -22,6 +22,7 @@
 
 #include "Apply_move.hpp"
 
+using namespace cdt;
 using namespace std;
 using namespace manifolds;
 
@@ -116,7 +117,7 @@ namespace
     if (succeeded == 1)
     {
       CHECK_EQ(result.simplices(), before.simplices() + cell_delta);
-      CHECK(ergodic_moves::check_move(before, result, move));
+      CHECK(ergodic_moves::detail::check_move(before, result, move));
     }
     else
     {
@@ -194,8 +195,8 @@ SCENARIO("Invoking a move with a function pointer" *
         cdt::Random random{92};
         CAPTURE(random.seed());
         auto result = move23(manifold, random);
-        CHECK(ergodic_moves::check_move(manifold, result.value(),
-                                        move_tracker::move_type::TWO_THREE));
+        CHECK(ergodic_moves::detail::check_move(
+            manifold, result.value(), move_tracker::move_type::TWO_THREE));
       }
     }
   }
@@ -221,8 +222,8 @@ SCENARIO("Invoking a move with a lambda" * doctest::test_suite("move_command"))
         cdt::Random random{92};
         CAPTURE(random.seed());
         auto result = move23(manifold, random);
-        CHECK(ergodic_moves::check_move(manifold, result,
-                                        move_tracker::move_type::TWO_THREE));
+        CHECK(ergodic_moves::detail::check_move(
+            manifold, result, move_tracker::move_type::TWO_THREE));
       }
     }
   }
@@ -246,8 +247,8 @@ SCENARIO("Invoking a move with apply_move and a function pointer" *
         cdt::Random random{92};
         CAPTURE(random.seed());
         auto result = apply_move(manifold, move, random);
-        CHECK(ergodic_moves::check_move(manifold, result.value(),
-                                        move_tracker::move_type::TWO_THREE));
+        CHECK(ergodic_moves::detail::check_move(
+            manifold, result.value(), move_tracker::move_type::TWO_THREE));
       }
     }
   }

--- a/tests/Move_tracker_test.cpp
+++ b/tests/Move_tracker_test.cpp
@@ -16,6 +16,7 @@
 
 #include "Manifold.hpp"
 
+using namespace cdt;
 using namespace std;
 using namespace manifolds;
 using namespace move_tracker;

--- a/tests/Public_api_consumer.cpp
+++ b/tests/Public_api_consumer.cpp
@@ -1,0 +1,58 @@
+#include <concepts>
+#include <cstdint>
+#include <expected>
+#include <random>
+#include <string>
+#include <type_traits>
+
+#include "Ergodic_moves_3.hpp"
+#include "Metropolis.hpp"
+#include "Move_always.hpp"
+#include "Move_command.hpp"
+#include "Runtime_config.hpp"
+#include "S3Action.hpp"
+
+using Manifold    = cdt::manifolds::Manifold_3;
+using Move_result = std::expected<Manifold, std::string>;
+
+static_assert(std::same_as<cdt::Int_precision, std::int32_t>);
+static_assert(std::uniform_random_bit_generator<cdt::Random>);
+static_assert(std::same_as<cdt::Geometry_3, cdt::Geometry<3>>);
+static_assert(
+    std::same_as<cdt::foliated_triangulations::FoliatedTriangulation_3,
+                 cdt::foliated_triangulations::FoliatedTriangulation<3>>);
+static_assert(
+    std::same_as<cdt::MoveAlways_3,
+                 cdt::MoveStrategy<cdt::Strategies::MOVE_ALWAYS, Manifold>>);
+static_assert(
+    std::same_as<cdt::Metropolis_3,
+                 cdt::MoveStrategy<cdt::Strategies::METROPOLIS, Manifold>>);
+static_assert(std::is_constructible_v<cdt::MoveCommand<Manifold>, Manifold>);
+
+static_assert(requires(Manifold const& manifold, cdt::Random& random) {
+  { cdt::ergodic_moves::null_move(manifold) } -> std::same_as<Move_result>;
+  {
+    cdt::ergodic_moves::do_23_move(manifold, random)
+  } -> std::same_as<Move_result>;
+  {
+    cdt::ergodic_moves::do_32_move(manifold, random)
+  } -> std::same_as<Move_result>;
+  {
+    cdt::ergodic_moves::do_26_move(manifold, random)
+  } -> std::same_as<Move_result>;
+  {
+    cdt::ergodic_moves::do_62_move(manifold, random)
+  } -> std::same_as<Move_result>;
+  {
+    cdt::ergodic_moves::do_44_move(manifold, random)
+  } -> std::same_as<Move_result>;
+  {
+    cdt::ergodic_moves::propose_23_move(manifold, random)
+  } -> std::same_as<Move_result>;
+});
+
+static_assert(requires {
+  {
+    cdt::s3_action::make_physical_parameters(0.6L, 1.1L, 0.1L)
+  } -> std::same_as<cdt::s3_action::PhysicalParameters>;
+});

--- a/tests/Public_api_consumer.cpp
+++ b/tests/Public_api_consumer.cpp
@@ -49,6 +49,18 @@ static_assert(requires(Manifold const& manifold, cdt::Random& random) {
   {
     cdt::ergodic_moves::propose_23_move(manifold, random)
   } -> std::same_as<Move_result>;
+  {
+    cdt::ergodic_moves::propose_32_move(manifold, random)
+  } -> std::same_as<Move_result>;
+  {
+    cdt::ergodic_moves::propose_26_move(manifold, random)
+  } -> std::same_as<Move_result>;
+  {
+    cdt::ergodic_moves::propose_62_move(manifold, random)
+  } -> std::same_as<Move_result>;
+  {
+    cdt::ergodic_moves::propose_44_move(manifold, random)
+  } -> std::same_as<Move_result>;
 });
 
 static_assert(requires {

--- a/tests/Random_benchmark.cpp
+++ b/tests/Random_benchmark.cpp
@@ -17,6 +17,8 @@
 
 #include "Move_tracker.hpp"
 
+using namespace cdt;
+
 namespace
 {
   using Clock = std::chrono::steady_clock;

--- a/tests/Random_test.cpp
+++ b/tests/Random_test.cpp
@@ -18,6 +18,8 @@
 #include "Foliated_triangulation.hpp"
 #include "Utilities.hpp"
 
+using namespace cdt;
+
 SCENARIO("PCG runs are reproducible and independently split" *
          doctest::test_suite("random"))
 {

--- a/tests/Runtime_config_test.cpp
+++ b/tests/Runtime_config_test.cpp
@@ -14,6 +14,8 @@
 #include <limits>
 #include <type_traits>
 
+using namespace cdt;
+
 namespace
 {
   auto test_make_triangulation(bool const spherical, bool const toroidal,

--- a/tests/S3Action_test.cpp
+++ b/tests/S3Action_test.cpp
@@ -20,6 +20,8 @@
 
 #include "Manifold.hpp"
 
+using namespace cdt;
+using namespace cdt::s3_action;
 using namespace std;
 using namespace manifolds;
 

--- a/tests/Settings_test.cpp
+++ b/tests/Settings_test.cpp
@@ -16,6 +16,7 @@
 
 #include <concepts>
 
+using namespace cdt;
 using namespace std;
 
 SCENARIO("Check settings" * doctest::test_suite("settings"))

--- a/tests/Tetrahedron_test.cpp
+++ b/tests/Tetrahedron_test.cpp
@@ -16,6 +16,7 @@
 
 #include "Foliated_triangulation.hpp"
 
+using namespace cdt;
 using namespace std;
 using namespace foliated_triangulations;
 
@@ -72,7 +73,7 @@ SCENARIO("Find distances between points of the tetrahedron" *
   using Point                 = Point_t<3>;
   using Causal_vertices       = Causal_vertices_t<3>;
   using FoliatedTriangulation = FoliatedTriangulation_3;
-  using squared_distance      = TriangulationTraits<3>::squared_distance;
+  using squared_distance = detail::TriangulationTraits<3>::squared_distance;
   GIVEN("Points in a tetrahedron.")
   {
     auto origin         = Point{0, 0, 0};

--- a/tests/Torus_test.cpp
+++ b/tests/Torus_test.cpp
@@ -12,6 +12,8 @@
 
 #include "Torus_d.hpp"
 
+using namespace cdt::experimental::torus;
+
 SCENARIO("Torus construction" * doctest::test_suite("torus"))
 {
   std::size_t constexpr NUMBER_OF_POINTS = 250;

--- a/tests/Utilities_test.cpp
+++ b/tests/Utilities_test.cpp
@@ -23,6 +23,7 @@
 #include <string>
 #include <string_view>
 
+using namespace cdt;
 using namespace std;
 using namespace utilities;
 
@@ -322,8 +323,8 @@ SCENARIO("Reading and writing Delaunay triangulations to files" *
 
       THEN("The versioned payload trailer restores the complete causal state")
       {
-        CHECK_EQ(detail::canonical_topology_fingerprint(restored),
-                 detail::canonical_topology_fingerprint(annotated));
+        CHECK_EQ(utilities::detail::canonical_topology_fingerprint(restored),
+                 utilities::detail::canonical_topology_fingerprint(annotated));
       }
     }
     WHEN("A stochastic artifact is written with reproducibility metadata")

--- a/tests/Vertex_test.cpp
+++ b/tests/Vertex_test.cpp
@@ -17,6 +17,7 @@
 
 #include "Manifold.hpp"
 
+using namespace cdt;
 using namespace manifolds;
 
 static inline auto constexpr RADIUS_2 = 2.0 * std::numbers::inv_sqrt3_v<double>;


### PR DESCRIPTION
Move supported declarations into the cdt namespace, classify implementation helpers under detail, and document the supported API boundary. Retain line and branch coverage while disabling unreliable GCC function coverage records.

BREAKING CHANGE: Global and unrelated top-level project names are removed. Downstream code must qualify supported APIs through cdt.

Closes #115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added API boundary documentation (supported `cdt` surface, header classification, and compatibility expectations).
  * Updated README Quickstart/coverage details and refreshed generated docs to exclude additional internal symbols.
* **Refactor**
  * Standardized the public C++ entry points under the `cdt` namespace and scoped implementation/detail helpers separately.
* **Tests**
  * Added public-header compile-contract checks and updated move/audit assertions to target the intended helper surfaces.
* **Build/Chores**
  * Added `scripts/pkgx-env.sh` for interactive environment setup; disabled function coverage in coverage reports; pinned `uv` version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->