### PR TITLE
feat(triangulation): restore optional parallel insertion and removal

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -16,6 +16,12 @@ coverage:
     patch: false
     changes: false
 
+parsers:
+  lcov:
+    # LCOV reports branch detail on otherwise executed lines. Preserve that
+    # detail without treating every partially covered branch line as a miss.
+    partials_as_hits: true
+
 comment:
   layout: "reach, diff, flags, files, footer"
   behavior: default

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,13 +133,13 @@ target_link_libraries(project_options INTERFACE Boost::compat)
 # https://github.com/gabime/spdlog
 find_package(spdlog CONFIG REQUIRED)
 
-# https://github.com/intel/tbb
-find_package(TBB CONFIG REQUIRED)
-include(CGAL_TBB_support)
-if(NOT TARGET CGAL::TBB_support)
-  message(FATAL_ERROR "CGAL parallel triangulation requires CGAL::TBB_support")
-endif()
 if(ENABLE_PARALLEL_TRIANGULATION)
+  # https://github.com/intel/tbb
+  find_package(TBB CONFIG REQUIRED)
+  include(CGAL_TBB_support)
+  if(NOT TARGET CGAL::TBB_support)
+    message(FATAL_ERROR "CGAL parallel triangulation requires CGAL::TBB_support")
+  endif()
   target_link_libraries(project_options INTERFACE CGAL::TBB_support)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,8 @@ include(cmake/StaticAnalyzers.cmake)
 # Options ##
 option(BUILD_SHARED_LIBS "Enable compilation of shared libraries" OFF)
 option(ENABLE_TESTING "Enable building of tests" ON)
+option(ENABLE_PARALLEL_TRIANGULATION
+       "Enable CGAL parallel Delaunay insertion and removal in production targets" OFF)
 
 # Modules and scripts ##
 include(CTest)
@@ -133,6 +135,13 @@ find_package(spdlog CONFIG REQUIRED)
 
 # https://github.com/intel/tbb
 find_package(TBB CONFIG REQUIRED)
+include(CGAL_TBB_support)
+if(NOT TARGET CGAL::TBB_support)
+  message(FATAL_ERROR "CGAL parallel triangulation requires CGAL::TBB_support")
+endif()
+if(ENABLE_PARALLEL_TRIANGULATION)
+  target_link_libraries(project_options INTERFACE CGAL::TBB_support)
+endif()
 
 # Header files
 include_directories(BEFORE ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}/include)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -63,6 +63,7 @@
       "description": "Configure the AddressSanitizer and UndefinedBehaviorSanitizer diagnostics",
       "inherits": "unix-diagnostics",
       "cacheVariables": {
+        "ENABLE_PARALLEL_TRIANGULATION": true,
         "ENABLE_SANITIZER_ADDRESS": true,
         "ENABLE_SANITIZER_UNDEFINED_BEHAVIOR": true
       }

--- a/README.md
+++ b/README.md
@@ -157,10 +157,10 @@ Windows development.
 ### Current reference-suite status
 
 With the pinned baseline, the reference configuration and build succeed on macOS with AppleClang. The cross-platform
-`just build` command runs all 23 CTest entries through `scripts/build.sh` on Unix and `scripts/build.bat` on Windows:
-one unit-test launcher containing 90 doctest scenarios, one parallel-configuration launcher containing three scenarios,
-and 21 CLI integration tests. The same `reference-smoke` preset is the supported local and CI contract; there are no
-overlapping focused registrations that can pass while omitting another doctest suite.
+`just build` command runs all 22 CTest entries through `scripts/build.sh` on Unix and `scripts/build.bat` on Windows:
+one unit-test launcher containing 90 doctest scenarios and 21 CLI integration tests. The same `reference-smoke` preset
+is the supported local and CI contract; there are no overlapping focused registrations that can pass while omitting
+another doctest suite. The parallel-enabled AddressSanitizer configuration adds one launcher containing three scenarios.
 
 ## Setup
 
@@ -433,11 +433,11 @@ subsequent releases.
 ## Testing
 
 Run `just build`; it selects `scripts/build.sh` on Unix or `scripts\build.bat` on Windows, builds the test target, and
-executes all 23 CTest entries: one unit-test launcher containing 90 doctest scenarios, one parallel-configuration
-launcher containing three scenarios, and 21 executable integration tests covering normal CLI use and invalid-boundary
-rejection. CTest labels both C++ test launchers `unit`; the parallel test also carries `parallel` and `configuration`.
-Every process-level test is labeled `integration`, and invalid-input tests also carry the `cli-boundary` subcategory.
-Run `just ci` for the complete local validation gate.
+executes all 22 CTest entries: one unit-test launcher containing 90 doctest scenarios and 21 executable integration
+tests covering normal CLI use and invalid-boundary rejection. The parallel-enabled AddressSanitizer configuration adds
+one launcher containing three scenarios labeled `unit`, `parallel`, and `configuration`. Every process-level test is
+labeled `integration`, and invalid-input tests also carry the `cli-boundary` subcategory. Run `just ci` for the complete
+local validation gate.
 
 `just check` also runs the repository-owned Semgrep policy and its annotated
 fixtures. Use `just semgrep-test` while changing the rules and `just semgrep` to
@@ -523,7 +523,8 @@ just clang-tidy
 [AddressSanitizer] + [UndefinedBehaviorSanitizer], [LeakSanitizer], [MemorySanitizer], and [ThreadSanitizer] share the
 repository-owned Linux driver and CMake presets. Run one locally with `just sanitize asan`, `just sanitize lsan`,
 `just sanitize msan`, or `just sanitize tsan`; the GitHub Actions workflows invoke the same commands. MemorySanitizer
-remains experimental because third-party dependencies are not instrumented.
+remains experimental because third-party dependencies are not instrumented. AddressSanitizer enables the optional
+CGAL/TBB path and its parallel contract; ThreadSanitizer exercises the default sequential configuration.
 
 ## Optimizing Parameters
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ After building, run that fixture directly with:
 - [x] S3 Bulk action
 - [x] 3D Ergodic moves
 - [x] High-quality Random Number Generation with M.E. O'Neill's [PCG] library
-- [ ] Restore optional parallel triangulation with [TBB] ([#74](https://github.com/acgetchell/CDT-plusplus/issues/74))
+- [x] Restore optional parallel triangulation with [TBB] ([#74](https://github.com/acgetchell/CDT-plusplus/issues/74))
 - [x] Automated code analysis with [CodeQL]
 - [x] Build/debug with [Visual Studio 2022]
 - [x] Use [{fmt}] library (instead of `iostream`)
@@ -157,10 +157,10 @@ Windows development.
 ### Current reference-suite status
 
 With the pinned baseline, the reference configuration and build succeed on macOS with AppleClang. The cross-platform
-`just build` command runs all 22 CTest entries through `scripts/build.sh` on Unix and `scripts/build.bat` on Windows:
-one unit-test launcher containing 90 doctest scenarios and 21 CLI integration tests. The same `reference-smoke` preset
-is the supported local and CI contract; there are no overlapping focused registrations that can pass while omitting
-another doctest suite.
+`just build` command runs all 23 CTest entries through `scripts/build.sh` on Unix and `scripts/build.bat` on Windows:
+one unit-test launcher containing 90 doctest scenarios, one parallel-configuration launcher containing three scenarios,
+and 21 CLI integration tests. The same `reference-smoke` preset is the supported local and CI contract; there are no
+overlapping focused registrations that can pass while omitting another doctest suite.
 
 ## Setup
 
@@ -433,10 +433,11 @@ subsequent releases.
 ## Testing
 
 Run `just build`; it selects `scripts/build.sh` on Unix or `scripts\build.bat` on Windows, builds the test target, and
-executes all 22 CTest entries: one unit-test launcher containing 90 doctest scenarios plus 21 executable integration
-tests covering normal CLI use and invalid-boundary rejection. CTest labels the launcher `unit` and every process-level
-test `integration`; invalid-input tests also carry the `cli-boundary` subcategory. Run `just ci` for the complete local
-validation gate.
+executes all 23 CTest entries: one unit-test launcher containing 90 doctest scenarios, one parallel-configuration
+launcher containing three scenarios, and 21 executable integration tests covering normal CLI use and invalid-boundary
+rejection. CTest labels both C++ test launchers `unit`; the parallel test also carries `parallel` and `configuration`.
+Every process-level test is labeled `integration`, and invalid-input tests also carry the `cli-boundary` subcategory.
+Run `just ci` for the complete local validation gate.
 
 `just check` also runs the repository-owned Semgrep policy and its annotated
 fixtures. Use `just semgrep-test` while changing the rules and `just semgrep` to
@@ -497,7 +498,10 @@ The Codecov workflow runs this recipe, uploads only `build/coverage.info` with
 OIDC, and preserves both reports as a 14-day GitHub Actions artifact for local
 diagnosis. If report generation fails, the workflow also preserves the gcov
 inputs and CTest diagnostics for seven days. It does not rely on Codecov's
-automatic gcov discovery.
+automatic gcov discovery. Codecov retains the LCOV branch detail but counts an
+executed line with an uncovered branch as a line hit, keeping its project
+percentage comparable to LCOV's line rate; use the LCOV artifact for the
+separate branch-coverage rate.
 
 ### Static Analysis
 

--- a/include/Foliated_triangulation.hpp
+++ b/include/Foliated_triangulation.hpp
@@ -21,6 +21,7 @@
 #ifndef CDT_PLUSPLUS_FOLIATEDTRIANGULATION_HPP
 #define CDT_PLUSPLUS_FOLIATEDTRIANGULATION_HPP
 
+#include <CGAL/Bbox_3.h>
 #include <CGAL/Random.h>
 
 #include <algorithm>
@@ -28,6 +29,8 @@
 #include <functional>
 #include <iterator>
 #include <limits>
+#include <memory>
+#include <numeric>
 #include <type_traits>
 #include <utility>
 
@@ -81,6 +84,225 @@ namespace cdt
     concept ContainerType               = std::movable<C>;
 
     inline int constexpr MAX_FIX_PASSES = 50;
+
+#ifdef CGAL_LINKED_WITH_TBB
+    inline int constexpr LOCK_GRID_RESOLUTION = 50;
+
+    [[nodiscard]] inline auto pad_locking_box(CGAL::Bbox_3 const& box)
+        -> CGAL::Bbox_3
+    {
+      auto const padding = std::max({1.0, (box.xmax() - box.xmin()) * 0.01,
+                                     (box.ymax() - box.ymin()) * 0.01,
+                                     (box.zmax() - box.zmin()) * 0.01});
+      return {box.xmin() - padding, box.ymin() - padding, box.zmin() - padding,
+              box.xmax() + padding, box.ymax() + padding, box.zmax() + padding};
+    }
+
+    [[nodiscard]] inline auto default_locking_box() -> CGAL::Bbox_3
+    {
+      auto const extent = static_cast<double>(GV_BOUNDING_BOX_SIZE);
+      return {-extent, -extent, -extent, extent, extent, extent};
+    }
+
+    template <typename Iterator, typename Point_projection>
+    [[nodiscard]] auto locking_box(Iterator first, Iterator last,
+                                   Point_projection point_for) -> CGAL::Bbox_3
+    {
+      if (first == last) { return default_locking_box(); }
+
+      auto const box = std::accumulate(
+          std::next(first), last, std::invoke(point_for, *first).bbox(),
+          [&point_for](CGAL::Bbox_3 accumulated, auto const& value) {
+            return accumulated + std::invoke(point_for, value).bbox();
+          });
+      return pad_locking_box(box);
+    }
+
+    template <int dimension>
+    [[nodiscard]] auto locking_box(
+        Causal_vertices_t<dimension> const& causal_vertices) -> CGAL::Bbox_3
+    {
+      return locking_box(causal_vertices.begin(), causal_vertices.end(),
+                         [](auto const& causal_vertex) -> auto const& {
+                           return causal_vertex.first;
+                         });
+    }
+
+    template <int dimension>
+    [[nodiscard]] auto locking_box(Delaunay_t<dimension> const& triangulation)
+        -> CGAL::Bbox_3
+    {
+      return locking_box(
+          triangulation.finite_vertices_begin(),
+          triangulation.finite_vertices_end(),
+          [](auto const& vertex) -> auto const& { return vertex.point(); });
+    }
+#endif
+
+    /// @brief A Delaunay triangulation and the lock grid it observes.
+    /// @details CGAL stores a non-owning pointer to the lock grid. Declaring
+    /// the owner first guarantees that the triangulation is destroyed before
+    /// the grid, including while this state is transferred into its owner.
+    template <int dimension>
+    class Delaunay_state
+    {
+     public:
+      using Delaunay = Delaunay_t<dimension>;
+      using Kernel   = typename TriangulationTraits<dimension>::Kernel;
+
+#ifdef CGAL_LINKED_WITH_TBB
+      using Lock_data_structure = typename Delaunay::Lock_data_structure;
+      using Lock_owner          = std::unique_ptr<Lock_data_structure>;
+#else
+      struct Lock_owner
+      {};
+#endif
+
+      static_assert(
+          noexcept(std::declval<Delaunay&>().swap(std::declval<Delaunay&>())),
+          "Delaunay_state swap requires CGAL's swap to be noexcept.");
+      static_assert(std::is_nothrow_swappable_v<Lock_owner>,
+                    "Delaunay_state swap requires a non-throwing lock owner.");
+      static_assert(std::is_nothrow_move_constructible_v<Lock_owner> &&
+                        std::is_nothrow_move_constructible_v<Delaunay>,
+                    "Delaunay_state move construction requires non-throwing "
+                    "members.");
+
+     private:
+      Lock_owner m_lock_data_structure;
+      Delaunay   m_triangulation;
+
+      struct Pending_state
+      {
+        Lock_owner lock_data_structure;
+        Delaunay   triangulation;
+      };
+
+      [[nodiscard]] static auto make_empty_state() -> Pending_state
+      {
+#ifdef CGAL_LINKED_WITH_TBB
+        auto lock = std::make_unique<Lock_data_structure>(
+            locking_box<dimension>(Delaunay{}), LOCK_GRID_RESOLUTION);
+        Delaunay triangulation{Kernel{}, lock.get()};
+        return {std::move(lock), std::move(triangulation)};
+#else
+        return {Lock_owner{}, Delaunay{}};
+#endif
+      }
+
+      [[nodiscard]] static auto make_insertion_state(
+          Causal_vertices_t<dimension> const& causal_vertices) -> Pending_state
+      {
+#ifdef CGAL_LINKED_WITH_TBB
+        auto lock = std::make_unique<Lock_data_structure>(
+            locking_box<dimension>(causal_vertices), LOCK_GRID_RESOLUTION);
+        Delaunay triangulation{Kernel{}, lock.get()};
+        return {std::move(lock), std::move(triangulation)};
+#else
+        static_cast<void>(causal_vertices);
+        return {Lock_owner{}, Delaunay{}};
+#endif
+      }
+
+      [[nodiscard]] static auto make_adopted_state(Delaunay source)
+          -> Pending_state
+      {
+#ifdef CGAL_LINKED_WITH_TBB
+        auto lock = std::make_unique<Lock_data_structure>(
+            locking_box<dimension>(source), LOCK_GRID_RESOLUTION);
+        source.set_lock_data_structure(lock.get());
+        return {std::move(lock), std::move(source)};
+#else
+        source.set_lock_data_structure(nullptr);
+        return {Lock_owner{}, std::move(source)};
+#endif
+      }
+
+      explicit Delaunay_state(Pending_state state) noexcept
+          : m_lock_data_structure{std::move(state.lock_data_structure)}
+          , m_triangulation{std::move(state.triangulation)}
+      { state.triangulation.set_lock_data_structure(nullptr); }
+
+     public:
+      Delaunay_state() : Delaunay_state{make_empty_state()} {}
+
+      explicit Delaunay_state(
+          Causal_vertices_t<dimension> const& causal_vertices)
+          : Delaunay_state{make_insertion_state(causal_vertices)}
+      {
+        m_triangulation.insert(causal_vertices.begin(), causal_vertices.end());
+      }
+
+      explicit Delaunay_state(Delaunay source)
+          : Delaunay_state{make_adopted_state(std::move(source))}
+      {}
+
+      Delaunay_state(Delaunay_state const& other)
+          : Delaunay_state{Delaunay{other.m_triangulation}}
+      {}
+
+      Delaunay_state(Delaunay_state&& other) noexcept
+          : m_lock_data_structure{std::move(other.m_lock_data_structure)}
+          , m_triangulation{std::move(other.m_triangulation)}
+      { other.m_triangulation.set_lock_data_structure(nullptr); }
+
+      friend void swap(Delaunay_state& lhs, Delaunay_state& rhs) noexcept
+      {
+        lhs.m_triangulation.swap(rhs.m_triangulation);
+        using std::swap;
+        swap(lhs.m_lock_data_structure, rhs.m_lock_data_structure);
+      }
+
+      auto operator=(Delaunay_state const& other) -> Delaunay_state&
+      {
+        if (this != &other)
+        {
+          Delaunay_state copy{other};
+          swap(*this, copy);
+        }
+        return *this;
+      }
+
+      auto operator=(Delaunay_state&& other) noexcept -> Delaunay_state&
+      {
+        if (this != &other) { swap(*this, other); }
+        return *this;
+      }
+
+      ~Delaunay_state() = default;
+
+      [[nodiscard]] auto triangulation() const noexcept -> Delaunay const&
+      { return m_triangulation; }
+
+      /// @brief Mutable access for internal CGAL algorithms.
+      /// @pre The caller must not replace the triangulation's lock pointer.
+      [[nodiscard]] auto mutable_triangulation_unchecked() noexcept -> Delaunay&
+      { return m_triangulation; }
+
+      [[nodiscard]] auto lock_data_structure() const noexcept
+      {
+#ifdef CGAL_LINKED_WITH_TBB
+        return m_lock_data_structure.get();
+#else
+        return nullptr;
+#endif
+      }
+
+      [[nodiscard]] auto has_consistent_lock_binding() const noexcept -> bool
+      {
+        return m_triangulation.get_lock_data_structure() ==
+               lock_data_structure();
+      }
+
+      [[nodiscard]] auto into_detached_triangulation() && -> Delaunay
+      {
+        m_triangulation.set_lock_data_structure(nullptr);
+#ifdef CGAL_LINKED_WITH_TBB
+        m_lock_data_structure.reset();
+#endif
+        return std::move(m_triangulation);
+      }
+    };
   }  // namespace detail
 
   /// (n,m) is number of vertices on (lower, higher) timeslice
@@ -1007,7 +1229,13 @@ namespace cdt::foliated_triangulations
   /// @param foliation_spacing Radial separation between timeslices
   /// @param generator Caller-owned random stream whose state is maintained by
   /// the caller and advanced during this call
-  /// @return A Delaunay triangulation with a timevalue for each vertex
+  /// @return An owning Delaunay triangulation detached from the internal lock
+  /// grid
+  /// @details Construction uses the configured parallel range operations when
+  /// available. The returned triangulation does not borrow the temporary lock
+  /// grid and can safely outlive this call. Its subsequent range operations
+  /// are sequential; in a TBB-enabled build, callers can attach a compatible
+  /// lock grid that they own to re-enable parallel execution.
   /// @see [CGAL triangulations](../REFERENCES.md#cgal-triangulations)
   template <int dimension, std::uniform_random_bit_generator Generator>
   [[nodiscard]] auto make_triangulation(Int_precision const t_simplices,
@@ -1021,26 +1249,12 @@ namespace cdt::foliated_triangulations
     spdlog::debug("{} called.\n", CDT_PRETTY_FUNCTION);
 #endif
     fmt::print("\nGenerating universe ...\n");
-#ifdef CGAL_LINKED_WITH_TBB
-    // Construct the locking data-structure
-    // using the bounding-box of the points
-    auto bounding_box_size = static_cast<double>(t_timeslices + 1);
-    typename Delaunay_t<dimension>::Lock_data_structure locking_ds{
-        CGAL::Bbox_3{-bounding_box_size, -bounding_box_size, -bounding_box_size,
-                     bounding_box_size, bounding_box_size, bounding_box_size},
-        50
-    };
-    Delaunay_t<dimension> triangulation = Delaunay_t<dimension>{
-        detail::TriangulationTraits<3>::Kernel{}, &locking_ds};
-#else
-    Delaunay_t<dimension> triangulation = Delaunay_t<dimension>{};
-#endif
-
     // Make initial triangulation
     auto causal_vertices =
         make_foliated_ball<dimension>(t_simplices, t_timeslices, initial_radius,
                                       foliation_spacing, generator);
-    triangulation.insert(causal_vertices.begin(), causal_vertices.end());
+    detail::Delaunay_state<dimension> state{causal_vertices};
+    auto& triangulation = state.mutable_triangulation_unchecked();
 
     // Fix vertices
     for (auto passes = 1; passes < detail::MAX_FIX_PASSES + 1; ++passes)
@@ -1075,7 +1289,7 @@ namespace cdt::foliated_triangulations
 
     utilities::print_delaunay(triangulation);
     assert(!check_timevalues<dimension>(triangulation));
-    return triangulation;
+    return std::move(state).into_detached_triangulation();
   }  // make_triangulation
 
   /// FoliatedTriangulation class template
@@ -1103,14 +1317,13 @@ namespace cdt::foliated_triangulations
     using Vertex_container    = std::vector<Vertex_handle>;
     using Volume_entry        = std::pair<Int_precision, Facet_t<3>>;
     using Volume_by_timeslice = std::vector<Volume_entry>;
+    using Delaunay_state      = detail::Delaunay_state<3>;
 
-    static_assert(
-        noexcept(std::declval<Delaunay&>().swap(std::declval<Delaunay&>())),
-        "FoliatedTriangulation swap requires CGAL's swap to be noexcept.");
     static_assert(std::is_nothrow_swappable_v<double>,
                   "FoliatedTriangulation swap requires non-throwing scalars.");
     static_assert(
-        std::is_nothrow_swappable_v<Vertex_container> &&
+        std::is_nothrow_swappable_v<Delaunay_state> &&
+            std::is_nothrow_swappable_v<Vertex_container> &&
             std::is_nothrow_swappable_v<Cell_container> &&
             std::is_nothrow_swappable_v<Face_container> &&
             std::is_nothrow_swappable_v<Edge_container> &&
@@ -1119,7 +1332,7 @@ namespace cdt::foliated_triangulations
     static_assert(std::is_nothrow_swappable_v<Int_precision>,
                   "FoliatedTriangulation swap requires non-throwing bounds.");
     static_assert(
-        std::is_nothrow_move_constructible_v<Delaunay> &&
+        std::is_nothrow_move_constructible_v<Delaunay_state> &&
             std::is_nothrow_move_constructible_v<Vertex_container> &&
             std::is_nothrow_move_constructible_v<Cell_container> &&
             std::is_nothrow_move_constructible_v<Face_container> &&
@@ -1132,20 +1345,26 @@ namespace cdt::foliated_triangulations
         Face_container const& faces) -> Volume_by_timeslice
     { return collect_spacelike_facets<3>(std::span{faces}); }
 
-    [[nodiscard]] static auto require_nonempty(Delaunay triangulation)
-        -> Delaunay
+    [[nodiscard]] static auto require_nonempty(Delaunay_state state)
+        -> Delaunay_state
     {
-      if (triangulation.number_of_vertices() == 0)
+      if (state.triangulation().number_of_vertices() == 0)
       {
         throw std::invalid_argument(
             "A foliated triangulation must contain at least one vertex.");
       }
-      return triangulation;
+      return state;
     }
+
+    [[nodiscard]] auto triangulation() noexcept -> Delaunay&
+    { return m_delaunay_state.mutable_triangulation_unchecked(); }
+
+    [[nodiscard]] auto triangulation() const noexcept -> Delaunay const&
+    { return m_delaunay_state.triangulation(); }
 
     /// Data members initialized in order of declaration (Working Draft,
     /// Standard for C++ Programming Language, 11.9.3 section 13.3)
-    Delaunay            m_triangulation{Delaunay{}};
+    Delaunay_state      m_delaunay_state;
     double              m_initial_radius{INITIAL_RADIUS};
     double              m_foliation_spacing{FOLIATION_SPACING};
     Vertex_container    m_vertices;
@@ -1172,13 +1391,13 @@ namespace cdt::foliated_triangulations
     FoliatedTriangulation(FoliatedTriangulation const& other)
         : FoliatedTriangulation{}
     {
-      if (other.m_triangulation.number_of_vertices() == 0)
+      if (other.triangulation().number_of_vertices() == 0)
       {
         m_initial_radius    = other.m_initial_radius;
         m_foliation_spacing = other.m_foliation_spacing;
         return;
       }
-      FoliatedTriangulation copy{Delaunay{other.m_triangulation},
+      FoliatedTriangulation copy{Delaunay_state{other.m_delaunay_state},
                                  other.m_initial_radius,
                                  other.m_foliation_spacing};
       swap(copy, *this);
@@ -1195,9 +1414,8 @@ namespace cdt::foliated_triangulations
     }
 
     /// @brief Move constructor
-    /// @details Moves the triangulation and all handle caches directly,
-    /// without first performing the potentially throwing default
-    /// construction.
+    /// @details The invariant-bearing Delaunay state transfers its lock owner
+    /// and detaches the moved-from triangulation as one operation.
     FoliatedTriangulation(FoliatedTriangulation&& other) noexcept = default;
 
     /// @brief Move assignment operator
@@ -1218,12 +1436,12 @@ namespace cdt::foliated_triangulations
     friend void swap(FoliatedTriangulation& swap_from,
                      FoliatedTriangulation& swap_into) noexcept
     {
-      // Uses the triangulation swap method in CGAL
-      // This assumes that the first triangulation is not used afterward!
+      // Delaunay_state swaps the triangulations before their lock owners so
+      // each triangulation remains paired with the grid it observes.
       // See
       // https://doc.cgal.org/latest/Triangulation_3/classCGAL_1_1Triangulation__3.html#a767066a964b4d7b14376e5f5d1a04b34
-      swap_into.m_triangulation.swap(swap_from.m_triangulation);
       using std::swap;
+      swap(swap_from.m_delaunay_state, swap_into.m_delaunay_state);
       swap(swap_from.m_initial_radius, swap_into.m_initial_radius);
       swap(swap_from.m_foliation_spacing, swap_into.m_foliation_spacing);
       swap(swap_from.m_vertices, swap_into.m_vertices);
@@ -1250,11 +1468,19 @@ namespace cdt::foliated_triangulations
     explicit FoliatedTriangulation(
         Delaunay triangulation, double const initial_radius = INITIAL_RADIUS,
         double const foliation_spacing = FOLIATION_SPACING)
-        : m_triangulation{require_nonempty(std::move(triangulation))}
+        : FoliatedTriangulation{Delaunay_state{std::move(triangulation)},
+                                initial_radius, foliation_spacing}
+    {}
+
+   private:
+    explicit FoliatedTriangulation(Delaunay_state state,
+                                   double const   initial_radius,
+                                   double const   foliation_spacing)
+        : m_delaunay_state{require_nonempty(std::move(state))}
         , m_initial_radius{initial_radius}
         , m_foliation_spacing{foliation_spacing}
-        , m_vertices{classify_vertices(collect_vertices<3>(m_triangulation))}
-        , m_cells{classify_cells(collect_cells<3>(m_triangulation))}
+        , m_vertices{classify_vertices(collect_vertices<3>(triangulation()))}
+        , m_cells{classify_cells(collect_cells<3>(triangulation()))}
         , m_three_one{filter_cells<3>(m_cells, Cell_type::THREE_ONE)}
         , m_two_two{filter_cells<3>(m_cells, Cell_type::TWO_TWO)}
         , m_one_three{filter_cells<3>(m_cells, Cell_type::ONE_THREE)}
@@ -1267,6 +1493,7 @@ namespace cdt::foliated_triangulations
         , m_min_timevalue{find_min_timevalue<3>(std::span{m_vertices})}
     {}
 
+   public:
     /// @brief Constructor with a caller-owned initialization stream.
     /// @param t_simplices Desired number of simplices
     /// @param t_timeslices Desired number of timeslices
@@ -1310,10 +1537,8 @@ namespace cdt::foliated_triangulations
         Causal_vertices_t<3> const& causal_vertices,
         double const                t_initial_radius    = INITIAL_RADIUS,
         double const                t_foliation_spacing = FOLIATION_SPACING)
-        : FoliatedTriangulation{
-              Delaunay{causal_vertices.begin(), causal_vertices.end()},
-              t_initial_radius, t_foliation_spacing
-    }
+        : FoliatedTriangulation{Delaunay_state{causal_vertices},
+                                t_initial_radius, t_foliation_spacing}
     {}
 
     /// @brief Verifies the triangulation is properly foliated
@@ -1324,16 +1549,16 @@ namespace cdt::foliated_triangulations
     /// @return True if foliated correctly
     [[nodiscard]] auto is_foliated() const -> bool
     {
-      return !static_cast<bool>(check_timevalues<3>(m_triangulation));
+      return !static_cast<bool>(check_timevalues<3>(triangulation()));
     }  // is_foliated
 
     /// @return True if the triangulation is Delaunay
     [[nodiscard]] auto is_delaunay() const -> bool
-    { return m_triangulation.is_valid(); }  // is_delaunay
+    { return triangulation().is_valid(); }  // is_delaunay
 
     /// @return True if the triangulation data structure is valid
     [[nodiscard]] auto is_tds_valid() const -> bool
-    { return m_triangulation.tds().is_valid(); }  // is_tds_valid
+    { return triangulation().tds().is_valid(); }  // is_tds_valid
 
     /// @return True if the Foliated Triangulation class invariants hold
     [[nodiscard]] auto is_correct() const -> bool
@@ -1349,7 +1574,7 @@ namespace cdt::foliated_triangulations
     /// @return True if fixes were done on the Delaunay triangulation
     [[nodiscard]] auto is_fixed() -> bool
     {
-      Delaunay   updated{m_triangulation};
+      Delaunay   updated{triangulation()};
       auto const fixed_vertices = foliated_triangulations::fix_vertices<3>(
           updated, m_initial_radius, m_foliation_spacing);
       auto const fixed_cells = foliated_triangulations::fix_cells<3>(updated);
@@ -1369,32 +1594,37 @@ namespace cdt::foliated_triangulations
     /// @details Mutating the returned value cannot invalidate this object's
     /// cached topology classifications.
     [[nodiscard]] auto delaunay_snapshot() const -> Delaunay
-    { return m_triangulation; }  // delaunay_snapshot
+    {
+      Delaunay snapshot{triangulation()};
+      // A snapshot does not own this object's lock grid and can outlive it.
+      snapshot.set_lock_data_structure(nullptr);
+      return snapshot;
+    }  // delaunay_snapshot
 
     /// @return Number of 3D simplices in triangulation data structure
     [[nodiscard]] auto number_of_finite_cells() const
     {
-      return m_triangulation.number_of_finite_cells();
+      return triangulation().number_of_finite_cells();
     }  // number_of_finite_cells
 
     /// @return Number of 2D faces in triangulation data structure
     [[nodiscard]] auto number_of_finite_facets() const
     {
-      return m_triangulation.number_of_finite_facets();
+      return triangulation().number_of_finite_facets();
     }  // number_of_finite_facets
 
     /// @return Number of 1D edges in triangulation data structure
     [[nodiscard]] auto number_of_finite_edges() const
     {
-      return m_triangulation.number_of_finite_edges();
+      return triangulation().number_of_finite_edges();
     }  // number_of_finite_edges
 
     /// @return Number of vertices in triangulation data structure
     [[nodiscard]] auto number_of_vertices() const
-    { return m_triangulation.number_of_vertices(); }  // number_of_vertices
+    { return triangulation().number_of_vertices(); }  // number_of_vertices
 
     /// @return Dimensionality of triangulation data structure (int)
-    [[nodiscard]] auto dimension() const { return m_triangulation.dimension(); }
+    [[nodiscard]] auto dimension() const { return triangulation().dimension(); }
 
     /// @return Number of spacelike facets on a timeslice
     [[nodiscard]] auto spacelike_face_count(
@@ -1475,13 +1705,13 @@ namespace cdt::foliated_triangulations
     [[nodiscard]] auto check_all_vertices() const -> bool
     {
       return foliated_triangulations::check_vertices<3>(
-          m_triangulation, m_initial_radius, m_foliation_spacing);
+          triangulation(), m_initial_radius, m_foliation_spacing);
     }  // check_all_vertices
 
     /// @brief Fix vertices with wrong timevalues after foliation
     [[nodiscard]] auto fix_vertices() -> bool
     {
-      Delaunay   updated{m_triangulation};
+      Delaunay   updated{triangulation()};
       auto const changed = foliated_triangulations::fix_vertices<3>(
           updated, m_initial_radius, m_foliation_spacing);
       if (changed)
@@ -1547,13 +1777,13 @@ namespace cdt::foliated_triangulations
     /// @return True if there are no cells or all cells are validly classified
     [[nodiscard]] auto check_all_cells() const -> bool
     {
-      return foliated_triangulations::check_cells<3>(m_triangulation);
+      return foliated_triangulations::check_cells<3>(triangulation());
     }  // check_all_cells
 
     /// @brief Fix all cells in the triangulation
     auto fix_cells() -> bool
     {
-      Delaunay   updated{m_triangulation};
+      Delaunay   updated{triangulation()};
       auto const changed = foliated_triangulations::fix_cells<3>(updated);
       if (changed)
       {
@@ -1612,17 +1842,17 @@ namespace cdt::foliated_triangulations
       // Somewhere in bistellar_flip_really a vertex is rendered invalid
       assert(is_tds_valid());
       Face_container init_faces;
-      init_faces.reserve(m_triangulation.number_of_finite_facets());
-      for (auto fit = m_triangulation.finite_facets_begin();
-           fit != m_triangulation.finite_facets_end(); ++fit)
+      init_faces.reserve(triangulation().number_of_finite_facets());
+      for (auto fit = triangulation().finite_facets_begin();
+           fit != triangulation().finite_facets_end(); ++fit)
       {
         Cell_handle_t<3> const cell = fit->first;
         // Each face is valid in the triangulation
-        assert(m_triangulation.tds().is_facet(cell, fit->second));
+        assert(triangulation().tds().is_facet(cell, fit->second));
         Face_handle_t<3> const thisFacet{std::make_pair(cell, fit->second)};
         init_faces.emplace_back(thisFacet);
       }
-      assert(init_faces.size() == m_triangulation.number_of_finite_facets());
+      assert(init_faces.size() == triangulation().number_of_finite_facets());
       return init_faces;
     }  // collect_faces
 
@@ -1632,15 +1862,15 @@ namespace cdt::foliated_triangulations
       assert(is_tds_valid());
       Edge_container init_edges;
       init_edges.reserve(number_of_finite_edges());
-      for (auto eit = m_triangulation.finite_edges_begin();
-           eit != m_triangulation.finite_edges_end(); ++eit)
+      for (auto eit = triangulation().finite_edges_begin();
+           eit != triangulation().finite_edges_end(); ++eit)
       {
         Cell_handle_t<3> const cell = eit->first;
         Edge_handle_t<3> const thisEdge{cell,
                                         cell->index(cell->vertex(eit->second)),
                                         cell->index(cell->vertex(eit->third))};
         // Each edge is valid in the triangulation
-        assert(m_triangulation.tds().is_valid(thisEdge.first, thisEdge.second,
+        assert(triangulation().tds().is_valid(thisEdge.first, thisEdge.second,
                                               thisEdge.third));
         init_edges.emplace_back(thisEdge);
       }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,6 @@ target_link_libraries(
           Boost::program_options
           fmt::fmt-header-only
           spdlog::spdlog_header_only
-          TBB::tbb
           CGAL::CGAL)
 target_compile_features(initialize PRIVATE cxx_std_23)
 
@@ -20,7 +19,6 @@ target_link_libraries(
           Boost::program_options
           fmt::fmt-header-only
           spdlog::spdlog_header_only
-          TBB::tbb
           CGAL::CGAL)
 target_compile_features(cdt PRIVATE cxx_std_23)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,8 +30,20 @@ target_link_libraries(
           date::date-tz
           doctest::doctest
           fmt::fmt-header-only
-          TBB::tbb
           CGAL::CGAL)
+
+add_executable(CDT_parallel_triangulation_test
+               ${PROJECT_SOURCE_DIR}/tests/main.cpp
+               Parallel_triangulation_test.cpp)
+target_compile_features(CDT_parallel_triangulation_test PRIVATE cxx_std_23)
+target_link_libraries(
+  CDT_parallel_triangulation_test
+  PRIVATE project_options
+          project_warnings
+          doctest::doctest
+          fmt::fmt-header-only
+          CGAL::CGAL
+          CGAL::TBB_support)
 
 # Compile Random.hpp through only the repository-owned project boundary so PCG
 # cannot remain available solely through another vcpkg target's include path.
@@ -50,7 +62,6 @@ target_link_libraries(
           date::date-tz
           fmt::fmt-header-only
           spdlog::spdlog_header_only
-          TBB::tbb
           CGAL::CGAL)
 
 # Compile every supported header as the first include in an independent
@@ -97,7 +108,6 @@ target_link_libraries(
           date::date-tz
           fmt::fmt-header-only
           spdlog::spdlog_header_only
-          TBB::tbb
           CGAL::CGAL)
 
 # Keep the issue #105 before/after diagnostic buildable without registering it
@@ -114,6 +124,11 @@ target_link_libraries(
 
 # Run unit tests
 add_test(NAME cdt-unit-tests COMMAND $<TARGET_FILE:CDT_unit_tests>)
+add_test(NAME cdt-parallel-triangulation
+         COMMAND $<TARGET_FILE:CDT_parallel_triangulation_test>)
+set_tests_properties(
+  cdt-parallel-triangulation
+  PROPERTIES LABELS "unit;parallel;configuration" TIMEOUT 60)
 set(cdt_unit_test_timeout 180)
 if(ENABLE_SANITIZER_ADDRESS)
   # CGAL-heavy unit tests routinely need 12-19 minutes under ASan on hosted runners.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,18 +32,20 @@ target_link_libraries(
           fmt::fmt-header-only
           CGAL::CGAL)
 
-add_executable(CDT_parallel_triangulation_test
-               ${PROJECT_SOURCE_DIR}/tests/main.cpp
-               Parallel_triangulation_test.cpp)
-target_compile_features(CDT_parallel_triangulation_test PRIVATE cxx_std_23)
-target_link_libraries(
-  CDT_parallel_triangulation_test
-  PRIVATE project_options
-          project_warnings
-          doctest::doctest
-          fmt::fmt-header-only
-          CGAL::CGAL
-          CGAL::TBB_support)
+if(ENABLE_PARALLEL_TRIANGULATION)
+  add_executable(CDT_parallel_triangulation_test
+                 ${PROJECT_SOURCE_DIR}/tests/main.cpp
+                 Parallel_triangulation_test.cpp)
+  target_compile_features(CDT_parallel_triangulation_test PRIVATE cxx_std_23)
+  target_link_libraries(
+    CDT_parallel_triangulation_test
+    PRIVATE project_options
+            project_warnings
+            doctest::doctest
+            fmt::fmt-header-only
+            CGAL::CGAL
+            CGAL::TBB_support)
+endif()
 
 # Compile Random.hpp through only the repository-owned project boundary so PCG
 # cannot remain available solely through another vcpkg target's include path.
@@ -124,11 +126,13 @@ target_link_libraries(
 
 # Run unit tests
 add_test(NAME cdt-unit-tests COMMAND $<TARGET_FILE:CDT_unit_tests>)
-add_test(NAME cdt-parallel-triangulation
-         COMMAND $<TARGET_FILE:CDT_parallel_triangulation_test>)
-set_tests_properties(
-  cdt-parallel-triangulation
-  PROPERTIES LABELS "unit;parallel;configuration" TIMEOUT 60)
+if(ENABLE_PARALLEL_TRIANGULATION)
+  add_test(NAME cdt-parallel-triangulation
+           COMMAND $<TARGET_FILE:CDT_parallel_triangulation_test>)
+  set_tests_properties(
+    cdt-parallel-triangulation
+    PROPERTIES LABELS "unit;parallel;configuration" TIMEOUT 60)
+endif()
 set(cdt_unit_test_timeout 180)
 if(ENABLE_SANITIZER_ADDRESS)
   # CGAL-heavy unit tests routinely need 12-19 minutes under ASan on hosted runners.

--- a/tests/Parallel_triangulation_test.cpp
+++ b/tests/Parallel_triangulation_test.cpp
@@ -1,0 +1,160 @@
+/*******************************************************************************
+ Causal Dynamical Triangulations in C++ using CGAL
+
+ Copyright © 2026 Adam Getchell
+ ******************************************************************************/
+
+/// @file Parallel_triangulation_test.cpp
+/// @brief Configuration contract for CGAL's oneTBB triangulation path
+
+#include <doctest/doctest.h>
+
+#include <concepts>
+#include <random>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "Foliated_triangulation.hpp"
+
+using namespace cdt;
+using namespace cdt::foliated_triangulations;
+
+static_assert(std::same_as<detail::TriangulationTraits<3>::Tds::Concurrency_tag,
+                           CGAL::Parallel_tag>);
+static_assert(!std::is_aggregate_v<detail::Delaunay_state<3>>);
+static_assert(std::copyable<detail::Delaunay_state<3>>);
+static_assert(std::is_nothrow_move_constructible_v<detail::Delaunay_state<3>>);
+
+TEST_CASE("Lock-grid bounds fold point ranges into one padded value" *
+          doctest::test_suite("parallel_triangulation"))
+{
+  Causal_vertices_t<3> const empty_vertices;
+  CHECK(detail::locking_box<3>(empty_vertices) ==
+        CGAL::Bbox_3{-GV_BOUNDING_BOX_SIZE, -GV_BOUNDING_BOX_SIZE,
+                     -GV_BOUNDING_BOX_SIZE, GV_BOUNDING_BOX_SIZE,
+                     GV_BOUNDING_BOX_SIZE, GV_BOUNDING_BOX_SIZE});
+
+  Causal_vertices_t<3> const vertices{
+      {Point_t<3>{-2.0, -3.0, -4.0}, 1},
+      { Point_t<3>{5.0, -3.0, -4.0}, 1},
+      { Point_t<3>{-2.0, 6.0, -4.0}, 2},
+      { Point_t<3>{-2.0, -3.0, 7.0}, 2},
+  };
+  auto const expected = CGAL::Bbox_3{-3.0, -4.0, -5.0, 6.0, 7.0, 8.0};
+  CHECK(detail::locking_box<3>(vertices) == expected);
+}
+
+TEST_CASE("CGAL parallel insertion and removal retain their lock-grid owner" *
+          doctest::test_suite("parallel_triangulation"))
+{
+  Random                                 generator{74};
+  std::uniform_real_distribution<double> coordinate{-10.0, 10.0};
+  Causal_vertices_t<3>                   vertices;
+  vertices.reserve(256);
+  for (Int_precision index = 0; index < 256; ++index)
+  {
+    vertices.emplace_back(
+        Point_t<3>{coordinate(generator), coordinate(generator),
+                   coordinate(generator)},
+        index % 4 + 1);
+  }
+
+  auto triangulation = [&vertices] {
+    detail::Delaunay_state<3> state{vertices};
+    REQUIRE(state.lock_data_structure() != nullptr);
+    CHECK(state.has_consistent_lock_binding());
+    CHECK(state.triangulation().is_parallel());
+    CHECK(detail::locking_box<3>(state.triangulation()) ==
+          detail::locking_box<3>(vertices));
+    REQUIRE(state.triangulation().number_of_vertices() > 100);
+    REQUIRE(state.triangulation().is_valid());
+
+    detail::Delaunay_state<3> const copied{state};
+    REQUIRE(copied.lock_data_structure() != nullptr);
+    CHECK(copied.lock_data_structure() != state.lock_data_structure());
+    CHECK(copied.has_consistent_lock_binding());
+    CHECK(copied.triangulation().is_valid());
+
+    detail::Delaunay_state<3> moved{std::move(state)};
+    REQUIRE(moved.lock_data_structure() != nullptr);
+    CHECK(state.lock_data_structure() == nullptr);
+    CHECK(state.has_consistent_lock_binding());
+    CHECK(moved.has_consistent_lock_binding());
+
+    auto& delaunay = moved.mutable_triangulation_unchecked();
+    std::vector<Vertex_handle_t<3>> vertices_to_remove;
+    vertices_to_remove.reserve(16);
+    auto vertex = delaunay.finite_vertices_begin();
+    for (std::size_t count = 0; count < 16; ++count, ++vertex)
+    {
+      vertices_to_remove.emplace_back(vertex);
+    }
+
+    CHECK(
+        delaunay.remove(vertices_to_remove.begin(), vertices_to_remove.end()) ==
+        vertices_to_remove.size());
+    CHECK(moved.has_consistent_lock_binding());
+    CHECK(delaunay.is_valid());
+
+    return FoliatedTriangulation_3{Delaunay_t<3>{moved.triangulation()}, 0.0,
+                                   1.0};
+  }();
+  CHECK(triangulation.is_delaunay());
+
+  auto snapshot = triangulation.delaunay_snapshot();
+  CHECK_FALSE(snapshot.is_parallel());
+  CHECK(snapshot.get_lock_data_structure() == nullptr);
+  CHECK(snapshot.is_valid());
+}
+
+TEST_CASE("Parallel lock ownership survives wrapper value transfers" *
+          doctest::test_suite("parallel_triangulation"))
+{
+  Causal_vertices_t<3> const vertices{
+      {Point_t<3>{1.0, 0.0, 0.0}, 1},
+      {Point_t<3>{0.0, 1.0, 0.0}, 1},
+      {Point_t<3>{0.0, 0.0, 1.0}, 1},
+      {Point_t<3>{0.0, 0.0, 2.0}, 2},
+      {Point_t<3>{2.0, 0.0, 0.0}, 2},
+      {Point_t<3>{0.0, 3.0, 0.0}, 3},
+  };
+  FoliatedTriangulation_3 const original{vertices};
+
+  auto verify_after_donor_destruction = [](FoliatedTriangulation_3& candidate) {
+    CHECK_FALSE(candidate.is_initialized());
+    CHECK(candidate.is_fixed());
+    CHECK(candidate.is_initialized());
+    CHECK(candidate.number_of_vertices() == 5);
+    auto snapshot = candidate.delaunay_snapshot();
+    CHECK_FALSE(snapshot.is_parallel());
+    CHECK(snapshot.get_lock_data_structure() == nullptr);
+    CHECK(snapshot.is_valid());
+  };
+
+  auto copy_constructed = [&original] {
+    FoliatedTriangulation_3 donor{original};
+    return FoliatedTriangulation_3{donor};
+  }();
+  verify_after_donor_destruction(copy_constructed);
+
+  auto move_constructed = [&original] {
+    FoliatedTriangulation_3 donor{original};
+    return FoliatedTriangulation_3{std::move(donor)};
+  }();
+  verify_after_donor_destruction(move_constructed);
+
+  FoliatedTriangulation_3 copy_assigned;
+  {
+    FoliatedTriangulation_3 const donor{original};
+    copy_assigned = donor;
+  }
+  verify_after_donor_destruction(copy_assigned);
+
+  FoliatedTriangulation_3 move_assigned;
+  {
+    FoliatedTriangulation_3 donor{original};
+    move_assigned = std::move(donor);
+  }
+  verify_after_donor_destruction(move_assigned);
+}

--- a/tests/Public_api_consumer.cpp
+++ b/tests/Public_api_consumer.cpp
@@ -6,6 +6,7 @@
 #include <type_traits>
 
 #include "Ergodic_moves_3.hpp"
+#include "Foliated_triangulation.hpp"
 #include "Metropolis.hpp"
 #include "Move_always.hpp"
 #include "Move_command.hpp"
@@ -21,6 +22,11 @@ static_assert(std::same_as<cdt::Geometry_3, cdt::Geometry<3>>);
 static_assert(
     std::same_as<cdt::foliated_triangulations::FoliatedTriangulation_3,
                  cdt::foliated_triangulations::FoliatedTriangulation<3>>);
+static_assert(requires(cdt::Random& random) {
+  {
+    cdt::foliated_triangulations::make_triangulation<3>(2, 2, 1.0, 1.0, random)
+  } -> std::same_as<cdt::Delaunay_t<3>>;
+});
 static_assert(
     std::same_as<cdt::MoveAlways_3,
                  cdt::MoveStrategy<cdt::Strategies::MOVE_ALWAYS, Manifold>>);


### PR DESCRIPTION
- add an opt-in CGAL/TBB production configuration
- preserve lock-grid ownership across copies, moves, swaps, and snapshots
- align Codecov line accounting with LCOV coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in build option to enable CGAL parallel triangulation via TBB.
  * Preserved lock-grid ownership/behavior across triangulation construction, copy, move, and detaching.
  * Added a dedicated parallel triangulation test run (including ASan parallel scenarios).

* **Documentation**
  * Updated CI/CTest expectations and reference-suite entry counts.
  * Refined Coverage/Codecov guidance and clarified sanitizer behavior for parallel vs sequential runs.

* **Tests**
  * Added a parallel triangulation test covering correctness and lock ownership semantics.
  * Added a public API compile-time compatibility check.

* **Chores**
  * Updated Codecov parsing to treat partial LCOV branch hits as hits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->