### PR TITLE
feat(cgal)!: modernize the CGAL 6.2 integration boundary

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -48,7 +48,7 @@ substantial implementation so its maintenance value and scope can be agreed upon
    ```
 
    `just check` is the fast, non-mutating source and tooling gate, including the repository-owned Semgrep policy and
-   its fixtures. `just ci` adds the supported build and complete 22-entry CTest suite: all 90 doctest unit scenarios
+   its fixtures. `just ci` adds the supported build and complete 22-entry CTest suite: all 103 doctest unit scenarios
    and 21 CLI integration tests. When changing C++ behavior, also run
    `just clang-tidy` with the pinned LLVM 22 toolchain and review its advisory diagnostics.
    GitHub Actions runs the same `just ci` contract in its Ubuntu GCC, Ubuntu Clang, macOS AppleClang, and Windows

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,24 +76,39 @@ option(BUILD_SHARED_LIBS "Enable compilation of shared libraries" OFF)
 option(ENABLE_TESTING "Enable building of tests" ON)
 option(ENABLE_PARALLEL_TRIANGULATION
        "Enable CGAL parallel Delaunay insertion and removal in production targets" OFF)
+option(ENABLE_DEPRECATION_ERRORS
+       "Treat deprecated C++ and CGAL API use in project targets as an error" ON)
+
+target_compile_definitions(
+  project_options
+  INTERFACE CDT_ENABLE_PARALLEL_TRIANGULATION=$<BOOL:${ENABLE_PARALLEL_TRIANGULATION}>)
+
+if(ENABLE_DEPRECATION_ERRORS)
+  if(MSVC)
+    target_compile_options(project_options INTERFACE /we4996)
+  else()
+    target_compile_options(project_options INTERFACE -Werror=deprecated-declarations)
+  endif()
+endif()
 
 # Modules and scripts ##
 include(CTest)
 include(CMakeDependentOption)
 
-# Minimum compiler versions required for C++23 support:
+# Minimum compiler versions required by the intersection of C++23 library
+# support and CGAL 6.2's tested platforms:
 # - MSVC 19.34 (Visual Studio 2022 version 17.4)
-# - GCC 12.2
+# - GCC 13.3
 # - AppleClang 15.0 (Xcode 15)
-# - Clang 16.0
+# - Clang 22.0
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.34")
   message(FATAL_ERROR "MSVC 19.34 or higher required for C++23 support")
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "12.2")
-  message(FATAL_ERROR "GCC 12.2 or higher required for C++23 support")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "13.3")
+  message(FATAL_ERROR "GCC 13.3 or higher required for CGAL 6.2 support")
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "15.0")
   message(FATAL_ERROR "AppleClang 15.0 (Xcode 15) or higher required for C++23 std::expected support")
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "16.0")
-  message(FATAL_ERROR "Clang 16.0 or higher required for C++23 support")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "22.0")
+  message(FATAL_ERROR "Clang 22.0 or higher required for CGAL 6.2 support")
 endif()
 
 # Set NOMINMAX to avoid min/max macro errors on Windows in date.h
@@ -109,7 +124,7 @@ endif()
 set(CGAL_DONT_OVERRIDE_CMAKE_FLAGS
     TRUE
     CACHE BOOL "Force CGAL to maintain CMAKE flags")
-find_package(CGAL CONFIG REQUIRED)
+find_package(CGAL 6.2 EXACT CONFIG REQUIRED)
 
 # https://howardhinnant.github.io/date/date.html
 find_package(date CONFIG REQUIRED)
@@ -122,6 +137,7 @@ find_package(fmt CONFIG REQUIRED)
 
 # https://github.com/microsoft/GSL
 find_package(Microsoft.GSL CONFIG REQUIRED)
+target_link_libraries(project_options INTERFACE Microsoft.GSL::GSL)
 
 # https://www.pcg-random.org
 find_path(PCG_INCLUDE_DIRS "pcg_extras.hpp" REQUIRED)

--- a/Justfile
+++ b/Justfile
@@ -17,6 +17,7 @@ graphviz_version := "15.1.0"
 zizmor_version := "1.26.1"
 primary_binary := if os_family() == "windows" { "out/build/reference/src/cdt.exe" } else { "out/build/reference/src/cdt" }
 rng_benchmark_binary := if os_family() == "windows" { "out/build/reference/tests/CDT_rng_benchmark.exe" } else { "out/build/reference/tests/CDT_rng_benchmark" }
+cgal_benchmark_binary := if os_family() == "windows" { "out/build/reference/tests/CDT_cgal_benchmark.exe" } else { "out/build/reference/tests/CDT_cgal_benchmark" }
 
 # Build the supported configuration through the repository build script.
 [group('workflows')]
@@ -63,6 +64,11 @@ coverage:
 benchmark-rng draws='10000': build
     {{ rng_benchmark_binary }} {{ draws }}
 
+# Measure seeded CGAL construction, repair, lookup, removal, and moves.
+[group('workflows')]
+benchmark-cgal simplices='640' repetitions='5' moves='50': build
+    {{ cgal_benchmark_binary }} {{ simplices }} {{ repetitions }} {{ moves }}
+
 # Apply safe automatic formatting to C++/Python source and the Justfile.
 [group('workflows')]
 fix: _format-fix python-fix
@@ -72,7 +78,26 @@ fix: _format-fix python-fix
 # Run Clang-Tidy with the pinned LLVM toolchain.
 [group('workflows')]
 clang-tidy:
-    ./scripts/clang-tidy.sh
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! command -v pkgx >/dev/null 2>&1; then
+        exec ./scripts/clang-tidy.sh
+    fi
+    exec pkgx \
+      +git-scm.org@2.55.0 \
+      "+just.systems@{{ just_version }}" \
+      "+llvm.org@{{ llvm_version }}" \
+      "+cmake.org@{{ cmake_version }}" \
+      "+ninja-build.org@{{ ninja_version }}" \
+      +python.org@3.11.15 \
+      +gnu.org/m4@1.4.21 \
+      +gnu.org/autoconf@2.73.0 \
+      +gnu.org/autoconf-archive@2024.10.16 \
+      +gnu.org/automake@1.18.1 \
+      +gnu.org/libtool@2.5.4 \
+      +gnu.org/texinfo@7.3.0 \
+      +freedesktop.org/pkg-config@0.29.2 \
+      -- ./scripts/clang-tidy.sh
 
 # Validate release metadata, citation fields, and version synchronization.
 [group('workflows')]

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ Arbitrary-precision numbers and functions are by [MPFR] and [GMP].
 [Doxygen] provides automated document generation.
 The supported C++ namespace and per-header contract are recorded in the
 [C++ API boundary](docs/api-boundary.md).
+The exact CGAL version, kernel, TDS, metadata, lifetime, TBB, benchmark, and
+upgrade policies are recorded in the
+[CGAL 6.2 integration contract](docs/cgal-integration.md).
 [{fmt}] provides a safe and fast alternative to `iostream`.
 [spdlog] provides fast, multithreaded logging.
 [CometML] provides experiment tracking for the optional Python workflows.
@@ -158,9 +161,9 @@ Windows development.
 
 With the pinned baseline, the reference configuration and build succeed on macOS with AppleClang. The cross-platform
 `just build` command runs all 22 CTest entries through `scripts/build.sh` on Unix and `scripts/build.bat` on Windows:
-one unit-test launcher containing 90 doctest scenarios and 21 CLI integration tests. The same `reference-smoke` preset
+one unit-test launcher containing 103 doctest scenarios and 21 CLI integration tests. The same `reference-smoke` preset
 is the supported local and CI contract; there are no overlapping focused registrations that can pass while omitting
-another doctest suite. The parallel-enabled AddressSanitizer configuration adds one launcher containing three scenarios.
+another doctest suite. The parallel-enabled AddressSanitizer configuration adds one launcher containing four scenarios.
 
 ## Setup
 
@@ -433,9 +436,9 @@ subsequent releases.
 ## Testing
 
 Run `just build`; it selects `scripts/build.sh` on Unix or `scripts\build.bat` on Windows, builds the test target, and
-executes all 22 CTest entries: one unit-test launcher containing 90 doctest scenarios and 21 executable integration
+executes all 22 CTest entries: one unit-test launcher containing 103 doctest scenarios and 21 executable integration
 tests covering normal CLI use and invalid-boundary rejection. The parallel-enabled AddressSanitizer configuration adds
-one launcher containing three scenarios labeled `unit`, `parallel`, and `configuration`. Every process-level test is
+one launcher containing four scenarios labeled `unit`, `parallel`, and `configuration`. Every process-level test is
 labeled `integration`, and invalid-input tests also carry the `cli-boundary` subcategory. Run `just ci` for the complete
 local validation gate.
 

--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -36,22 +36,13 @@ if(ENABLE_IPO)
   endif()
 endif()
 
-# Set minimum Boost version
-set(BOOST_MIN_VERSION "1.75.0")
-
 # Use C++23
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Turn on / off TBB
-set(TBB_ON ON)
-
 # Threads
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
-
-# Turn off CGAL Triangulation Assertions and Postconditions, fix https://gitlab.com/libeigen/eigen/-/issues/1894
-add_definitions(-DCGAL_TRIANGULATION_NO_ASSERTIONS -DCGAL_TRIANGULATION_NO_POSTCONDITIONS -D_HAS_DEPRECATED_RESULT_OF=1 -DEIGEN_HAS_STD_RESULT_OF=0 -DCGAL_USE_GMP=ON -DCGAL_USE_MPFR=ON -DCGAL_DO_NOT_USE_BOOST_MP=ON)
 
 # Easier navigation in an IDE when projects are organized in folders.
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)

--- a/docs/api-boundary.md
+++ b/docs/api-boundary.md
@@ -46,10 +46,11 @@ failure-atomicity and malformed-handle rejection. Test access does not promote
 those declarations into the supported API.
 
 The supported-header compile contract intentionally excludes `experimental`.
-In particular, the periodic prototypes still depend on CGAL interfaces that
-are absent or incompatible in CGAL 6.2; issue #102 owns that integration work.
+The CGAL 6.2 audit confirmed that the periodic and d-dimensional prototypes are
+not production dependencies and do not meet the supported compile contract.
 Their presence under `include/` preserves archival source access, not a promise
-that they are usable downstream.
+that they are usable downstream. See the
+[CGAL integration contract](cgal-integration.md).
 
 ## Compatibility policy
 

--- a/docs/cgal-integration.md
+++ b/docs/cgal-integration.md
@@ -1,0 +1,214 @@
+# CGAL 6.2 integration contract
+
+This document records the supported CGAL boundary for CDT++ 1.0. It is the
+audit record for issue #102 and complements the
+[C++ API boundary](api-boundary.md), the
+[ergodic-move contract](ergodic-moves.md), and the
+[reproducibility contract](reproducibility.md).
+
+## Supported dependency and compiler contract
+
+The repository-owned vcpkg baseline in `vcpkg.json` is the dependency source
+of truth. CMake requires exactly CGAL 6.2 and treats deprecated declarations as
+errors by default. The baseline currently resolves CGAL 6.2 with Boost 1.91.0,
+GMP 6.3.0 revision 4, MPFR 4.2.2 revision 1, and oneTBB 2023.0.0. Those
+transitive versions are a resolution record for the pinned baseline, not
+independent version promises.
+
+The supported compiler floor is the intersection of CDT++'s C++23 library
+requirements and CGAL 6.2's tested platforms:
+
+| Compiler | Minimum accepted by CMake |
+| --- | --- |
+| GCC | 13.3 |
+| upstream Clang | 22.0 |
+| AppleClang | 15.0 (Xcode 15) |
+| MSVC | 19.34 (Visual Studio 2022 17.4) |
+
+CI exercises newer representatives of this matrix. A successful local
+configuration demonstrates only that local compiler and platform; it does not
+substitute for the other CI cells.
+
+`ENABLE_DEPRECATION_ERRORS=ON` adds `/we4996` with MSVC and
+`-Werror=deprecated-declarations` elsewhere. `CGAL_DONT_OVERRIDE_CMAKE_FLAGS`
+keeps warning, sanitizer, and optimization policy under repository control.
+CDT++ does not disable CGAL triangulation assertions or postconditions.
+
+## Production usage inventory
+
+| Surface | Classification | CGAL 6.2 decision |
+| --- | --- | --- |
+| `Triangulation_traits.hpp` kernel and info bases | Modernized | Retain EPICK; compose the cell info base over `Delaunay_triangulation_cell_base_3`; select the TDS concurrency tag explicitly; publish canonical Delaunay handle, facet, and edge types. |
+| `Delaunay_state` construction and ownership | Modernized | Retain bulk point/info range insertion; reject duplicate geometric points with ambiguous labels; own the parallel lock grid with the triangulation and detach it before returning an unowned triangulation. |
+| `FoliatedTriangulation` traversal and caches | Modernized | Use finite handle and simplex ranges; rebuild and verify all derived handle caches at the owning mutation boundary. |
+| Causality repair and vertex removal | Retained | Keep CGAL range removal and cavity retriangulation; every published replacement is constructed on a private copy and rebuilds caches before swap. |
+| Point lookup | Retained | The current zero-overhead adapter adds optional absence handling and is used at stable point-value mutation boundaries. |
+| Checked Delaunay and TDS flips | Retained | CGAL establishes combinatorial/geometric flippability; typed applicable moves independently establish CDT causal admissibility. |
+| Persistence and fingerprints | Modernized | Use finite handle ranges while preserving canonical sorting. Native CGAL stream data remains version-coupled and is not claimed as a stable interchange format. |
+| Spherical point generation | Retained | A caller-owned CDT random stream seeds `CGAL::Random`; the generated sequence and the limits of cospherical topology replay are documented separately. |
+| CGAL timers and visualization | Removed from production | Production code uses standard timing and has no CGAL timer dependency. Qt visualization remains separately owned by issue #98. |
+| Periodic 3D and d-dimensional torus prototypes | Excluded | These remain under `cdt::experimental`, outside supported-header compilation and production dependency decisions. They are archival source, not supported CGAL 6.2 APIs. |
+
+No production path uses a deprecated CGAL triangulation API. Canonical
+`Delaunay::Vertex_handle`, `Cell_handle`, `Facet`, and `Edge` types are retained
+where they are the clearest zero-overhead representation; CDT++ does not add a
+wrapper solely to hide CGAL.
+
+## Kernel and exact-arithmetic policy
+
+Production triangulation uses
+`CGAL::Exact_predicates_inexact_constructions_kernel` (EPICK). CDT++ relies on
+exact orientation and sphere-side predicates for Delaunay insertion, point
+location, and checked geometric flips. Coordinates, centroids, distances, and
+other constructed values remain floating-point approximations.
+
+That split is intentional. The scientific state is the causal combinatorial
+triangulation plus time and cell metadata; it is not a claim that every
+constructed coordinate is exact. The integration suite includes an almost
+coplanar orientation fixture and a co-spherical insertion fixture before any
+future kernel change. There is no reproduced construction defect that
+justifies the runtime, memory, persistence, and semantic cost of moving to an
+exact-constructions kernel.
+
+GMP and MPFR are retained. CGAL's `Gmpzf` is part of the existing exact-number
+surface, and CDT action and Metropolis calculations directly use
+`CGAL::Gmpfr` at 256-bit precision. The pinned CGAL port supplies and links
+GMP/MPFR through `CGAL::CGAL`. Boost.Multiprecision is present through CGAL,
+but replacing these production types would be a numerical and persistence
+migration, not a dependency-only cleanup. No such migration is proposed
+without adversarial equivalence tests and compile-time, runtime, and peak-memory
+measurements from the benchmark protocol below.
+
+## Metadata, insertion, and duplicate points
+
+Vertices store one `Int_precision` time value and cells store one
+`Int_precision` causal cell type through CGAL's info-bearing bases. The cell
+base is layered over the Delaunay-specific base so it satisfies the current
+cell concept, including the circumcenter operation.
+
+Construction inserts the point/info pairs as one range, allowing CGAL's
+spatially sorted bulk path while preserving pair association. The number of
+inserted vertices must equal the number of input pairs. Two labels for one
+geometric point would otherwise collapse to one vertex with ambiguous
+metadata, so that input is rejected rather than normalized. Time values
+arriving from wider unsigned types are range-checked before conversion.
+
+Co-spherical inputs can have more than one mathematically valid Delaunay
+triangulation. CDT++ tests validity and point/label preservation but does not
+promise identical fresh topology across toolchains; see
+[Reproducible random runs](reproducibility.md).
+
+## Mutation and lifetime rules
+
+CGAL documents that every triangulation modification invalidates iterators.
+Checked TDS flips preserve vertex handles and invalidate cell handles only for
+the affected cells. Removal destroys the selected vertex and its incident
+cells while retriangulating the cavity. CDT++ deliberately applies the
+following stricter owning rule:
+
+| Operation | CDT++ lifetime action |
+| --- | --- |
+| Bulk insertion or repair insertion | Construct unpublished state, then build every vertex, cell, facet, edge, and classification cache. |
+| Vertex or range removal | Mutate a private triangulation; do not retain any cached simplex or circulator across the call. |
+| Facet or edge flip | Resolve point-value locators immediately before mutation; retain no affected cell handle after the checked flip. |
+| Copy | Treat every handle in the copy as belonging to the copy; rebuild wrapper caches from its canonical triangulation. |
+| Move or swap | Transfer the lock owner, triangulation, caches, and scalar bounds together. |
+| Public snapshot | Return an owning triangulation with no borrowed lock-grid pointer; snapshot handles cannot mutate the source wrapper. |
+| Published replacement | Validate TDS, foliation, metadata, counts, and derived-cache consistency before a non-throwing swap. |
+
+The underlying mutable triangulation accessor is an internal CGAL algorithm
+boundary. Public callers receive a read-only view or an owning snapshot, so
+they cannot silently mutate canonical topology while leaving geometry or
+handle caches stale.
+
+## Checked flips and CDT admissibility
+
+CGAL's checked `flip()` operations remain the mutation primitive where the
+geometric or combinatorial precondition can still fail. Low-level TDS
+operations are used only behind move-specific applicable values that prove the
+local CDT topology, foliation, simplex-type, and metadata contract.
+
+A successful CGAL flip is therefore necessary but not sufficient for a CDT
+move. Mutations occur on private copies, postconditions are checked, and only a
+valid replacement is published. The detailed per-move proof and invalidation
+record is in [2+1D CDT ergodic move audit](ergodic-moves.md).
+
+## Sequential and TBB-backed configurations
+
+The reference build sets `ENABLE_PARALLEL_TRIANGULATION=OFF` and instantiates
+the TDS with `CGAL::Sequential_tag`. Enabling the option:
+
+1. requires oneTBB;
+2. imports CGAL's current `CGAL::TBB_support` target;
+3. links `TBB::tbb`, `TBB::tbbmalloc`, and the platform thread target through
+   that CGAL target;
+4. defines CGAL's `CGAL_LINKED_WITH_TBB` capability; and
+5. instantiates the TDS with `CGAL::Parallel_tag`.
+
+`CDT_ENABLE_PARALLEL_TRIANGULATION` records repository policy.
+`CGAL_LINKED_WITH_TBB` remains a capability supplied by the linked CGAL target;
+the traits header rejects a parallel policy without that capability. Merely
+including TBB headers or setting the CGAL macro manually is unsupported.
+
+Each parallel `Delaunay_state` owns the lock grid referenced by its
+triangulation. Copies allocate and bind their own grid; moves transfer the
+owner and pointer together. Returned snapshots are detached and operate
+sequentially unless a new owner explicitly attaches a compatible grid. The
+focused parallel test covers insertion, point/info association, copy, move,
+lock-zone refusal without mutation, range removal, wrapper transfer, and
+post-donor lifetime. Issue #88 owns scaling and any broader multithreaded
+simulation policy.
+
+## Reproducible performance baseline
+
+The benchmark is diagnostic rather than a pass/fail test:
+
+```console
+just benchmark-cgal 640 5 50
+```
+
+The arguments are requested simplices, repetitions, and queued moves per
+repetition. Input generation uses seed `102`. The report includes CGAL version,
+TDS mode, generated and surviving topology counts, a checksum, and
+minimum/median/maximum nanoseconds for:
+
+- bulk point/info insertion;
+- foliation repair;
+- wrapper and cache construction;
+- point lookup;
+- triangulation snapshot copying;
+- range vertex removal; and
+- a representative five-move queued workload.
+
+The seed fixes the generated input and move stream, not CGAL's choice among
+valid co-spherical tetrahedralizations or the resulting foliation repair.
+Topology counts and the checksum are comparison diagnostics, not strict
+fresh-construction replay identities; see
+[Reproducible random runs](reproducibility.md).
+
+Compare builds only on the same machine, build type, compiler, dependency
+baseline, and TDS mode. Record the commit, complete command, and raw output.
+Use `/usr/bin/time -l` on macOS or `/usr/bin/time -v` on Linux around the
+benchmark for peak resident memory. Time a clean target build separately when
+evaluating compile-time changes. A kernel, arithmetic-backend, or parallelism
+change must also compare topology counts, checksum, adversarial tests, and
+simulation observables; wall-clock time alone is not acceptance evidence.
+
+## Upgrade checklist
+
+For a future CGAL upgrade:
+
+1. update the pinned vcpkg baseline and the exact CMake version together;
+2. review CGAL release notes, the 3D Triangulations deprecated list, TDS
+   concepts, supported compilers, and the `CGAL::TBB_support` target;
+3. record the resolved Boost, GMP, MPFR, and TBB versions;
+4. build supported headers and API consumers with deprecations as errors;
+5. run sequential and parallel insertion/removal and lock-ownership tests;
+6. run near-degenerate, co-spherical, persistence, repair, and complete
+   deterministic move suites;
+7. regenerate the benchmark record on the same comparison host; and
+8. update this inventory for every retained, modernized, replaced, removed, or
+   newly experimental CGAL surface.
+
+Do not change the kernel, exact backend, persistence representation, or
+parallel simulation policy as an incidental part of a version bump.

--- a/docs/cgal-integration.md
+++ b/docs/cgal-integration.md
@@ -40,7 +40,7 @@ CDT++ does not disable CGAL triangulation assertions or postconditions.
 | --- | --- | --- |
 | `Triangulation_traits.hpp` kernel and info bases | Modernized | Retain EPICK; compose the cell info base over `Delaunay_triangulation_cell_base_3`; select the TDS concurrency tag explicitly; publish canonical Delaunay handle, facet, and edge types. |
 | `Delaunay_state` construction and ownership | Modernized | Retain bulk point/info range insertion; reject duplicate geometric points with ambiguous labels; own the parallel lock grid with the triangulation and detach it before returning an unowned triangulation. |
-| `FoliatedTriangulation` traversal and caches | Modernized | Use finite handle and simplex ranges; rebuild and verify all derived handle caches at the owning mutation boundary. |
+| `FoliatedTriangulation` traversal and caches | Modernized | Use finite handle and simplex ranges; rebuild all derived handle caches at the owning mutation boundary and expose an opt-in diagnostic comparison. |
 | Causality repair and vertex removal | Retained | Keep CGAL range removal and cavity retriangulation; every published replacement is constructed on a private copy and rebuilds caches before swap. |
 | Point lookup | Retained | The current zero-overhead adapter adds optional absence handling and is used at stable point-value mutation boundaries. |
 | Checked Delaunay and TDS flips | Retained | CGAL establishes combinatorial/geometric flippability; typed applicable moves independently establish CDT causal admissibility. |
@@ -114,7 +114,7 @@ following stricter owning rule:
 | Copy | Treat every handle in the copy as belonging to the copy; rebuild wrapper caches from its canonical triangulation. |
 | Move or swap | Transfer the lock owner, triangulation, caches, and scalar bounds together. |
 | Public snapshot | Return an owning triangulation with no borrowed lock-grid pointer; snapshot handles cannot mutate the source wrapper. |
-| Published replacement | Validate TDS, foliation, metadata, counts, and derived-cache consistency before a non-throwing swap. |
+| Published replacement | Rebuild derived caches and validate TDS, foliation, metadata, and tracked counts before a non-throwing swap; the full derived-cache comparison remains opt-in. |
 
 The underlying mutable triangulation accessor is an internal CGAL algorithm
 boundary. Public callers receive a read-only view or an owning snapshot, so

--- a/docs/ergodic-moves.md
+++ b/docs/ergodic-moves.md
@@ -62,7 +62,9 @@ None of these moves is required to preserve the Euclidean empty-sphere
 (Delaunay) property of the representative coordinates. The scientific state is
 a valid causal combinatorial triangulation. `tds().is_valid()` establishes the
 CGAL incidence and adjacency contract; `Manifold::is_correct()` adds foliation
-and causal cell-metadata checks.
+and causal cell-metadata checks without rebuilding derived caches. Call
+`Manifold::is_correct_with_diagnostics()` to opt into a full derived-cache
+comparison outside hot move paths.
 
 ## Move-by-move record
 

--- a/include/Ergodic_moves_3.hpp
+++ b/include/Ergodic_moves_3.hpp
@@ -1801,10 +1801,11 @@ namespace cdt::ergodic_moves
     return std::unexpected{flipped.error()};
   }
 
-  /// @brief Check tracked move deltas and the complete CDT manifold invariant
-  /// @details This verifies causal foliation, cell metadata, TDS validity,
-  /// geometry counts, time bounds, and preserved foliation parameters. It does
-  /// not require Euclidean Delaunayhood.
+  /// @brief Check tracked move deltas and essential CDT manifold invariants
+  /// @details This verifies structural cache counts, causal foliation, cell
+  /// metadata, TDS validity, geometry deltas, time bounds, and preserved
+  /// foliation parameters without rebuilding derived caches. It does not
+  /// require Euclidean Delaunayhood.
   /// @param t_before The manifold before the move
   /// @param t_after The manifold after the move
   /// @param t_move The type of move
@@ -1813,7 +1814,7 @@ namespace cdt::ergodic_moves
       Manifold const& t_before, Manifold const& t_after,
       move_tracker::move_type const& t_move) -> bool
   {
-    if (!t_after.is_correct() ||
+    if (!t_after.is_structurally_correct() ||
         !detail::same_configuration_value(t_after.initial_radius(),
                                           t_before.initial_radius()) ||
         !detail::same_configuration_value(t_after.foliation_spacing(),

--- a/include/Foliated_triangulation.hpp
+++ b/include/Foliated_triangulation.hpp
@@ -1374,20 +1374,38 @@ namespace cdt::foliated_triangulations
     Int_precision       m_max_timevalue{0};
     Int_precision       m_min_timevalue{0};
 
-    [[nodiscard]] auto  has_consistent_derived_state() const -> bool
+    [[nodiscard]] auto  has_consistent_structure() const -> bool
     {
       auto const& delaunay = triangulation();
-      auto const& tds      = delaunay.tds();
-      if (!m_delaunay_state.has_consistent_lock_binding() ||
-          m_vertices.size() != delaunay.number_of_vertices() ||
-          m_cells.size() != delaunay.number_of_finite_cells() ||
+      auto const  cells_are_partitioned =
+          m_three_one.size() + m_two_two.size() + m_one_three.size() ==
+          m_cells.size();
+      auto const edges_are_partitioned =
+          m_timelike_edges.size() + m_spacelike_edges.size() == m_edges.size();
+      auto const time_bounds_are_valid =
+          m_vertices.empty() ? m_max_timevalue == 0 && m_min_timevalue == 0
+                             : m_min_timevalue <= m_max_timevalue;
+      return m_delaunay_state.has_consistent_lock_binding() &&
+             m_vertices.size() == delaunay.number_of_vertices() &&
+             m_spacelike_facets.size() <= m_faces.size() &&
+             cells_are_partitioned && edges_are_partitioned &&
+             time_bounds_are_valid;
+    }
+
+    [[nodiscard]] auto has_consistent_derived_state() const -> bool
+    {
+      if (!has_consistent_structure()) { return false; }
+
+      auto const& delaunay = triangulation();
+      if (m_cells.size() != delaunay.number_of_finite_cells() ||
           m_faces.size() != delaunay.number_of_finite_facets() ||
           m_edges.size() != delaunay.number_of_finite_edges())
       {
         return false;
       }
 
-      auto const valid_vertices = std::ranges::all_of(
+      auto const& tds            = delaunay.tds();
+      auto const  valid_vertices = std::ranges::all_of(
           m_vertices,
           [&tds](Vertex_handle const vertex) { return tds.is_vertex(vertex); });
       auto const valid_cells = std::ranges::all_of(
@@ -1416,10 +1434,7 @@ namespace cdt::foliated_triangulations
         return false;
       }
 
-      if (m_vertices.empty())
-      {
-        return m_max_timevalue == 0 && m_min_timevalue == 0;
-      }
+      if (m_vertices.empty()) { return true; }
       return m_max_timevalue == find_max_timevalue<3>(std::span{m_vertices}) &&
              m_min_timevalue == find_min_timevalue<3>(std::span{m_vertices});
     }
@@ -1604,12 +1619,23 @@ namespace cdt::foliated_triangulations
     [[nodiscard]] auto is_tds_valid() const -> bool
     { return triangulation().tds().is_valid(); }  // is_tds_valid
 
-    /// @return True if the Foliated Triangulation class invariants hold
-    [[nodiscard]] auto is_correct() const -> bool
+    /// @return True if the essential structural and causal invariants hold
+    /// @details This path avoids rebuilding derived caches and is suitable for
+    /// validating move candidates.
+    [[nodiscard]] auto is_structurally_correct() const -> bool
     {
-      return is_foliated() && is_tds_valid() && check_all_cells() &&
-             has_consistent_derived_state();
-    }  // is_correct
+      return has_consistent_structure() && is_tds_valid() && check_all_cells();
+    }
+
+    /// @return True if the essential class invariants hold
+    [[nodiscard]] auto is_correct() const -> bool
+    { return is_structurally_correct(); }  // is_correct
+
+    /// @return True if all invariants and derived caches are consistent
+    /// @details This diagnostic path rescans cached handles and rebuilds
+    /// classifications for comparison. Prefer is_correct() in hot paths.
+    [[nodiscard]] auto is_correct_with_diagnostics() const -> bool
+    { return is_structurally_correct() && has_consistent_derived_state(); }
 
     /// @return True if the Foliated Triangulation has been initialized
     /// correctly

--- a/include/Foliated_triangulation.hpp
+++ b/include/Foliated_triangulation.hpp
@@ -25,14 +25,25 @@
 #include <CGAL/Random.h>
 
 #include <algorithm>
+#include <array>
+#include <cassert>
 #include <cmath>
+#include <concepts>
 #include <functional>
 #include <iterator>
 #include <limits>
+#include <map>
 #include <memory>
 #include <numeric>
+#include <optional>
+#include <ranges>
+#include <set>
+#include <span>
+#include <stdexcept>
 #include <type_traits>
+#include <unordered_set>
 #include <utility>
+#include <vector>
 
 #include "Random.hpp"
 #include "Triangulation_traits.hpp"
@@ -55,10 +66,6 @@ namespace cdt
       typename detail::TriangulationTraits<dimension>::Cell_handle;
 
   template <int dimension>
-  using Face_handle_t =
-      typename detail::TriangulationTraits<dimension>::Face_handle;
-
-  template <int dimension>
   using Facet_t = typename detail::TriangulationTraits<dimension>::Facet;
 
   template <int dimension>
@@ -73,19 +80,19 @@ namespace cdt
   using Spherical_points_generator_t = typename detail::TriangulationTraits<
       dimension>::Spherical_points_generator;
 
-  /// @concept ContainerType
-  /// @brief Requires `std::movable`, defined in the standard `<concepts>`
-  /// header.
-  /// @details Right now the real restriction on Containers is that elements
-  /// must be swappable in order for std::shuffle to work.
+  /// @concept ConstForwardRange
+  /// @brief A multi-pass range whose const-qualified value can be traversed by
+  /// classification and materialization helpers.
   namespace detail
   {
     template <typename C>
-    concept ContainerType               = std::movable<C>;
+    concept ConstForwardRange = std::ranges::forward_range<
+        std::add_const_t<std::remove_reference_t<C>>>;
 
     inline int constexpr MAX_FIX_PASSES = 50;
 
-#ifdef CGAL_LINKED_WITH_TBB
+#if defined(CDT_ENABLE_PARALLEL_TRIANGULATION) && \
+    CDT_ENABLE_PARALLEL_TRIANGULATION
     inline int constexpr LOCK_GRID_RESOLUTION = 50;
 
     [[nodiscard]] inline auto pad_locking_box(CGAL::Bbox_3 const& box)
@@ -132,10 +139,10 @@ namespace cdt
     [[nodiscard]] auto locking_box(Delaunay_t<dimension> const& triangulation)
         -> CGAL::Bbox_3
     {
+      auto const vertices = triangulation.finite_vertex_handles();
       return locking_box(
-          triangulation.finite_vertices_begin(),
-          triangulation.finite_vertices_end(),
-          [](auto const& vertex) -> auto const& { return vertex.point(); });
+          vertices.begin(), vertices.end(),
+          [](auto const vertex) -> auto const& { return vertex->point(); });
     }
 #endif
 
@@ -150,7 +157,8 @@ namespace cdt
       using Delaunay = Delaunay_t<dimension>;
       using Kernel   = typename TriangulationTraits<dimension>::Kernel;
 
-#ifdef CGAL_LINKED_WITH_TBB
+#if defined(CDT_ENABLE_PARALLEL_TRIANGULATION) && \
+    CDT_ENABLE_PARALLEL_TRIANGULATION
       using Lock_data_structure = typename Delaunay::Lock_data_structure;
       using Lock_owner          = std::unique_ptr<Lock_data_structure>;
 #else
@@ -180,7 +188,8 @@ namespace cdt
 
       [[nodiscard]] static auto make_empty_state() -> Pending_state
       {
-#ifdef CGAL_LINKED_WITH_TBB
+#if defined(CDT_ENABLE_PARALLEL_TRIANGULATION) && \
+    CDT_ENABLE_PARALLEL_TRIANGULATION
         auto lock = std::make_unique<Lock_data_structure>(
             locking_box<dimension>(Delaunay{}), LOCK_GRID_RESOLUTION);
         Delaunay triangulation{Kernel{}, lock.get()};
@@ -193,7 +202,8 @@ namespace cdt
       [[nodiscard]] static auto make_insertion_state(
           Causal_vertices_t<dimension> const& causal_vertices) -> Pending_state
       {
-#ifdef CGAL_LINKED_WITH_TBB
+#if defined(CDT_ENABLE_PARALLEL_TRIANGULATION) && \
+    CDT_ENABLE_PARALLEL_TRIANGULATION
         auto lock = std::make_unique<Lock_data_structure>(
             locking_box<dimension>(causal_vertices), LOCK_GRID_RESOLUTION);
         Delaunay triangulation{Kernel{}, lock.get()};
@@ -207,7 +217,8 @@ namespace cdt
       [[nodiscard]] static auto make_adopted_state(Delaunay source)
           -> Pending_state
       {
-#ifdef CGAL_LINKED_WITH_TBB
+#if defined(CDT_ENABLE_PARALLEL_TRIANGULATION) && \
+    CDT_ENABLE_PARALLEL_TRIANGULATION
         auto lock = std::make_unique<Lock_data_structure>(
             locking_box<dimension>(source), LOCK_GRID_RESOLUTION);
         source.set_lock_data_structure(lock.get());
@@ -230,7 +241,13 @@ namespace cdt
           Causal_vertices_t<dimension> const& causal_vertices)
           : Delaunay_state{make_insertion_state(causal_vertices)}
       {
-        m_triangulation.insert(causal_vertices.begin(), causal_vertices.end());
+        auto const inserted = m_triangulation.insert(causal_vertices.begin(),
+                                                     causal_vertices.end());
+        if (inserted != std::ssize(causal_vertices))
+        {
+          throw std::invalid_argument(
+              "Causal vertices must contain unique geometric points.");
+        }
       }
 
       explicit Delaunay_state(Delaunay source)
@@ -281,7 +298,8 @@ namespace cdt
 
       [[nodiscard]] auto lock_data_structure() const noexcept
       {
-#ifdef CGAL_LINKED_WITH_TBB
+#if defined(CDT_ENABLE_PARALLEL_TRIANGULATION) && \
+    CDT_ENABLE_PARALLEL_TRIANGULATION
         return m_lock_data_structure.get();
 #else
         return nullptr;
@@ -297,7 +315,8 @@ namespace cdt
       [[nodiscard]] auto into_detached_triangulation() && -> Delaunay
       {
         m_triangulation.set_lock_data_structure(nullptr);
-#ifdef CGAL_LINKED_WITH_TBB
+#if defined(CDT_ENABLE_PARALLEL_TRIANGULATION) && \
+    CDT_ENABLE_PARALLEL_TRIANGULATION
         m_lock_data_structure.reset();
 #endif
         return std::move(m_triangulation);
@@ -335,11 +354,15 @@ namespace cdt::foliated_triangulations
     }
     Causal_vertices_t<dimension> causal_vertices;
     causal_vertices.reserve(vertices.size());
-    std::ranges::transform(vertices, timevalues,
-                           std::back_inserter(causal_vertices),
-                           [](Point_t<dimension> point, size_t time) {
-                             return std::make_pair(point, time);
-                           });
+    std::ranges::transform(
+        vertices, timevalues, std::back_inserter(causal_vertices),
+        [](Point_t<dimension> point, size_t time) {
+          if (!std::in_range<Int_precision>(time))
+          {
+            throw std::out_of_range("Timevalue does not fit Int_precision.");
+          }
+          return std::pair{point, static_cast<Int_precision>(time)};
+        });
     return causal_vertices;
   }
 
@@ -355,16 +378,10 @@ namespace cdt::foliated_triangulations
     assert(delaunay.is_valid());
     std::vector<Edge_handle_t<dimension>> init_edges;
     init_edges.reserve(delaunay.number_of_finite_edges());
-    for (auto eit = delaunay.finite_edges_begin();
-         eit != delaunay.finite_edges_end(); ++eit)
+    for (auto const& edge : delaunay.finite_edges())
     {
-      Cell_handle_t<3> const cell = eit->first;
-      Edge_handle_t<3> thisEdge{cell, cell->index(cell->vertex(eit->second)),
-                                cell->index(cell->vertex(eit->third))};
-      // Each edge is valid in the triangulation
-      assert(delaunay.tds().is_valid(thisEdge.first, thisEdge.second,
-                                     thisEdge.third));
-      init_edges.emplace_back(thisEdge);
+      assert(delaunay.tds().is_valid(edge.first, edge.second, edge.third));
+      init_edges.emplace_back(edge);
     }
     assert(init_edges.size() == delaunay.number_of_finite_edges());
     return init_edges;
@@ -427,41 +444,33 @@ namespace cdt::foliated_triangulations
   /// @tparam dimension The dimensionality of the simplices
   /// @param t_vertices The container of vertices
   /// @returns The maximum timevalue in the container
-  template <int dimension, detail::ContainerType Container>
-  [[nodiscard]] auto find_max_timevalue(Container&& t_vertices) -> Int_precision
+  template <int dimension, detail::ConstForwardRange Container>
+  [[nodiscard]] auto find_max_timevalue(Container const& t_vertices)
+      -> Int_precision
   {
-    auto vertices = std::forward<Container>(t_vertices);
-    if (vertices.empty())
+    if (std::ranges::empty(t_vertices))
     {
       throw std::invalid_argument("Cannot classify an empty triangulation.");
     }
-    auto max_element  = std::max_element(vertices.begin(), vertices.end(),
-                                         compare_v_info<dimension>);
-    auto result_index = std::distance(vertices.begin(), max_element);
-    // std::distance may be negative if random-access iterators are used and
-    // first is reachable from last
-    assert(result_index >= 0);
-    auto const index = static_cast<std::size_t>(std::abs(result_index));
-    return vertices[index]->info();
+    auto const max_element =
+        std::ranges::max_element(t_vertices, compare_v_info<dimension>);
+    return (*max_element)->info();
   }  // find_max_timevalue
 
   /// @tparam dimension The dimensionality of the simplices
   /// @param t_vertices The container of vertices
   /// @returns The minimum timevalue in the container
-  template <int dimension, detail::ContainerType Container>
-  [[nodiscard]] auto find_min_timevalue(Container&& t_vertices) -> Int_precision
+  template <int dimension, detail::ConstForwardRange Container>
+  [[nodiscard]] auto find_min_timevalue(Container const& t_vertices)
+      -> Int_precision
   {
-    auto vertices = std::forward<Container>(t_vertices);
-    if (vertices.empty())
+    if (std::ranges::empty(t_vertices))
     {
       throw std::invalid_argument("Cannot classify an empty triangulation.");
     }
-    auto min_element  = std::min_element(vertices.begin(), vertices.end(),
-                                         compare_v_info<dimension>);
-    auto result_index = std::distance(vertices.begin(), min_element);
-    assert(result_index >= 0);
-    auto const index = static_cast<std::size_t>(std::abs(result_index));
-    return vertices[index]->info();
+    auto const min_element =
+        std::ranges::min_element(t_vertices, compare_v_info<dimension>);
+    return (*min_element)->info();
   }  // find_min_timevalue
 
   /// @brief Predicate to classify edge as timelike or spacelike
@@ -497,12 +506,11 @@ namespace cdt::foliated_triangulations
       bool t_is_Timelike_pred) -> std::vector<Edge_handle_t<dimension>>
   {
     std::vector<Edge_handle_t<dimension>> filtered_edges;
-    // Short-circuit if no edges
-    if (t_edges.empty()) { return filtered_edges; }
-    std::copy_if(t_edges.begin(), t_edges.end(),
-                 std::back_inserter(filtered_edges), [&](auto const& edge) {
-                   return t_is_Timelike_pred == classify_edge<dimension>(edge);
-                 });
+    filtered_edges.reserve(t_edges.size());
+    std::ranges::copy_if(
+        t_edges, std::back_inserter(filtered_edges), [&](auto const& edge) {
+          return t_is_Timelike_pred == classify_edge<dimension>(edge);
+        });
     return filtered_edges;
   }  // filter_edges
 
@@ -516,13 +524,11 @@ namespace cdt::foliated_triangulations
       Cell_type const& t_cell_type) -> std::vector<Cell_handle_t<dimension>>
   {
     std::vector<Cell_handle_t<dimension>> filtered_cells;
-    // Short-circuit if no cells
-    if (t_cells.empty()) { return filtered_cells; }
-    std::copy_if(t_cells.begin(), t_cells.end(),
-                 std::back_inserter(filtered_cells),
-                 [&t_cell_type](auto const& cell) {
-                   return cell->info() == static_cast<int>(t_cell_type);
-                 });
+    filtered_cells.reserve(t_cells.size());
+    std::ranges::copy_if(t_cells, std::back_inserter(filtered_cells),
+                         [&t_cell_type](auto const& cell) {
+                           return cell->info() == static_cast<int>(t_cell_type);
+                         });
     return filtered_cells;
   }  // filter_cells
 
@@ -593,12 +599,11 @@ namespace cdt::foliated_triangulations
       Delaunay_t<dimension> const& t_triangulation)
   {
     std::vector<Vertex_handle_t<dimension>> vertices;
-    for (auto vit = t_triangulation.finite_vertices_begin();
-         vit != t_triangulation.finite_vertices_end(); ++vit)
+    vertices.reserve(t_triangulation.number_of_vertices());
+    for (auto const vertex : t_triangulation.finite_vertex_handles())
     {
-      // Each vertex is valid
-      assert(t_triangulation.tds().is_vertex(vit));
-      vertices.emplace_back(vit);
+      assert(t_triangulation.tds().is_vertex(vertex));
+      vertices.emplace_back(vertex);
     }
     return vertices;
   }  // collect_vertices
@@ -615,12 +620,11 @@ namespace cdt::foliated_triangulations
       Delaunay_t<dimension> const& t_triangulation, double t_initial_radius,
       double t_foliation_spacing)
   {
-    auto checked_vertices = collect_vertices<dimension>(t_triangulation);
-    return std::all_of(checked_vertices.begin(), checked_vertices.end(),
-                       [&](auto const& vertex) {
-                         return is_vertex_timevalue_correct<dimension>(
-                             vertex, t_initial_radius, t_foliation_spacing);
-                       });
+    return std::ranges::all_of(
+        t_triangulation.finite_vertex_handles(), [&](auto const vertex) {
+          return is_vertex_timevalue_correct<dimension>(
+              vertex, t_initial_radius, t_foliation_spacing);
+        });
   }  // check_vertices
 
   /// @brief Obtain all finite cells in the Delaunay triangulation
@@ -632,12 +636,11 @@ namespace cdt::foliated_triangulations
       -> std::vector<Cell_handle_t<dimension>>
   {
     std::vector<Cell_handle_t<dimension>> cells;
-    for (auto cit = t_triangulation.finite_cells_begin();
-         cit != t_triangulation.finite_cells_end(); ++cit)
+    cells.reserve(t_triangulation.number_of_finite_cells());
+    for (auto const cell : t_triangulation.finite_cell_handles())
     {
-      // Each cell is valid
-      assert(t_triangulation.tds().is_cell(cit));
-      cells.emplace_back(cit);
+      assert(t_triangulation.tds().is_cell(cell));
+      cells.emplace_back(cell);
     }
     return cells;
   }  // collect_cells
@@ -825,12 +828,9 @@ namespace cdt::foliated_triangulations
   [[nodiscard]] auto check_cells(Delaunay_t<dimension> const& t_triangulation)
       -> bool
   {
-    auto checked_cells = collect_cells<dimension>(t_triangulation);
-    return checked_cells.empty() ||
-           std::all_of(checked_cells.begin(), checked_cells.end(),
-                       [&](auto const& cell) {
-                         return is_cell_type_correct<dimension>(cell);
-                       });
+    return std::ranges::all_of(
+        t_triangulation.finite_cell_handles(),
+        [](auto const cell) { return is_cell_type_correct<dimension>(cell); });
   }  // check_cells
 
   /// @brief Check all finite cells in the Delaunay triangulation
@@ -889,14 +889,10 @@ namespace cdt::foliated_triangulations
   /// cell->info()
   /// @tparam dimension The dimensionality of the simplices
   /// @param t_cells The cells to print
-  template <int dimension, typename Container>
-  void print_cells(Container&& t_cells)
+  template <int dimension, detail::ConstForwardRange Container>
+  void print_cells(Container const& t_cells)
   {
-    for (auto        cells = std::forward<Container>(t_cells);
-         auto const& cell : cells)
-    {
-      print_cell<dimension>(cell);
-    }
+    for (auto const& cell : t_cells) { print_cell<dimension>(cell); }
   }  // print_cells
 
   /// @brief Write to debug log timevalues of each vertex in the cell and the
@@ -904,11 +900,10 @@ namespace cdt::foliated_triangulations
   /// @tparam dimension The dimensionality of the simplices
   /// @tparam Container The type of container
   /// @param t_cells The cells to write to debug log
-  template <int dimension, detail::ContainerType Container>
-  void debug_print_cells(Container&& t_cells)
+  template <int dimension, detail::ConstForwardRange Container>
+  void debug_print_cells(Container const& t_cells)
   {
-    for (auto        cells = std::forward<Container>(t_cells);
-         auto const& cell : cells)
+    for (auto const& cell : t_cells)
     {
       spdlog::debug("Cell info => {}\n", cell->info());
       for (int j = 0; j < dimension + 1; ++j)
@@ -936,12 +931,11 @@ namespace cdt::foliated_triangulations
 
   /// @brief Print edge
   /// @details An edge is represented by a cell and two indices which refer
-  /// to the vertices of the cell connected by the edge. The data is stored
-  /// in a CGAL::Triple, which is an extension of std::pair.
+  /// to the vertices of the cell connected by the edge. The public type is
+  /// the triangulation's canonical `Delaunay::Edge` alias.
   /// @tparam dimension The dimensionality of the simplices
   /// @param t_edge The edge to print
   /// @see https://doc.cgal.org/latest/TDS_3/index.html#fig__TDS3figrepres
-  /// @see https://doc.cgal.org/latest/STL_Extension/classCGAL_1_1Triple.html
   template <int dimension>
   void print_edge(Edge_handle_t<dimension> const& t_edge)
   {
@@ -962,8 +956,8 @@ namespace cdt::foliated_triangulations
   /// @tparam dimension The dimensionality of the simplices
   /// @param t_facets A container of facets
   /// @return Contiguous container with spacelike facets per timeslice
-  template <int dimension, detail::ContainerType Container>
-  [[nodiscard]] auto collect_spacelike_facets(Container&& t_facets)
+  template <int dimension, detail::ConstForwardRange Container>
+  [[nodiscard]] auto collect_spacelike_facets(Container const& t_facets)
       -> std::vector<std::pair<Int_precision, Facet_t<3>>>
   {
 #ifndef NDEBUG
@@ -1022,7 +1016,7 @@ namespace cdt::foliated_triangulations
   /// @tparam dimension The dimensionality of the simplices
   /// @param t_facets A container of facets
   /// @return Container with spacelike facets per timeslice
-  template <int dimension, detail::ContainerType Container>
+  template <int dimension, detail::ConstForwardRange Container>
   [[nodiscard]] auto volume_per_timeslice(Container&& t_facets)
       -> std::multimap<Int_precision, Facet_t<3>>
   {
@@ -1311,7 +1305,7 @@ namespace cdt::foliated_triangulations
     using Delaunay            = Delaunay_t<3>;
     using Cell_handle         = Cell_handle_t<3>;
     using Cell_container      = std::vector<Cell_handle>;
-    using Face_container      = std::vector<Face_handle_t<3>>;
+    using Face_container      = std::vector<Facet_t<3>>;
     using Edge_container      = std::vector<Edge_handle_t<3>>;
     using Vertex_handle       = Vertex_handle_t<3>;
     using Vertex_container    = std::vector<Vertex_handle>;
@@ -1379,6 +1373,56 @@ namespace cdt::foliated_triangulations
     Edge_container      m_spacelike_edges;
     Int_precision       m_max_timevalue{0};
     Int_precision       m_min_timevalue{0};
+
+    [[nodiscard]] auto  has_consistent_derived_state() const -> bool
+    {
+      auto const& delaunay = triangulation();
+      auto const& tds      = delaunay.tds();
+      if (!m_delaunay_state.has_consistent_lock_binding() ||
+          m_vertices.size() != delaunay.number_of_vertices() ||
+          m_cells.size() != delaunay.number_of_finite_cells() ||
+          m_faces.size() != delaunay.number_of_finite_facets() ||
+          m_edges.size() != delaunay.number_of_finite_edges())
+      {
+        return false;
+      }
+
+      auto const valid_vertices = std::ranges::all_of(
+          m_vertices,
+          [&tds](Vertex_handle const vertex) { return tds.is_vertex(vertex); });
+      auto const valid_cells = std::ranges::all_of(
+          m_cells,
+          [&tds](Cell_handle const cell) { return tds.is_cell(cell); });
+      auto const valid_faces =
+          std::ranges::all_of(m_faces, [&tds](auto const& face) {
+            return tds.is_facet(face.first, face.second);
+          });
+      auto const valid_edges =
+          std::ranges::all_of(m_edges, [&tds](auto const& edge) {
+            return tds.is_valid(edge.first, edge.second, edge.third);
+          });
+      if (!valid_vertices || !valid_cells || !valid_faces || !valid_edges)
+      {
+        return false;
+      }
+
+      if (m_three_one != filter_cells<3>(m_cells, Cell_type::THREE_ONE) ||
+          m_two_two != filter_cells<3>(m_cells, Cell_type::TWO_TWO) ||
+          m_one_three != filter_cells<3>(m_cells, Cell_type::ONE_THREE) ||
+          m_spacelike_facets != cache_spacelike_facets(m_faces) ||
+          m_timelike_edges != filter_edges<3>(m_edges, true) ||
+          m_spacelike_edges != filter_edges<3>(m_edges, false))
+      {
+        return false;
+      }
+
+      if (m_vertices.empty())
+      {
+        return m_max_timevalue == 0 && m_min_timevalue == 0;
+      }
+      return m_max_timevalue == find_max_timevalue<3>(std::span{m_vertices}) &&
+             m_min_timevalue == find_min_timevalue<3>(std::span{m_vertices});
+    }
 
    public:
     /// @brief Default dtor
@@ -1486,7 +1530,7 @@ namespace cdt::foliated_triangulations
         , m_one_three{filter_cells<3>(m_cells, Cell_type::ONE_THREE)}
         , m_faces{collect_faces()}
         , m_spacelike_facets{cache_spacelike_facets(m_faces)}
-        , m_edges{collect_edges()}
+        , m_edges{foliated_triangulations::collect_edges<3>(triangulation())}
         , m_timelike_edges{filter_edges<3>(m_edges, true)}
         , m_spacelike_edges{filter_edges<3>(m_edges, false)}
         , m_max_timevalue{find_max_timevalue<3>(std::span{m_vertices})}
@@ -1563,7 +1607,8 @@ namespace cdt::foliated_triangulations
     /// @return True if the Foliated Triangulation class invariants hold
     [[nodiscard]] auto is_correct() const -> bool
     {
-      return is_foliated() && is_tds_valid() && check_all_cells();
+      return is_foliated() && is_tds_valid() && check_all_cells() &&
+             has_consistent_derived_state();
     }  // is_correct
 
     /// @return True if the Foliated Triangulation has been initialized
@@ -1843,40 +1888,14 @@ namespace cdt::foliated_triangulations
       assert(is_tds_valid());
       Face_container init_faces;
       init_faces.reserve(triangulation().number_of_finite_facets());
-      for (auto fit = triangulation().finite_facets_begin();
-           fit != triangulation().finite_facets_end(); ++fit)
+      for (auto const& facet : triangulation().finite_facets())
       {
-        Cell_handle_t<3> const cell = fit->first;
-        // Each face is valid in the triangulation
-        assert(triangulation().tds().is_facet(cell, fit->second));
-        Face_handle_t<3> const thisFacet{std::make_pair(cell, fit->second)};
-        init_faces.emplace_back(thisFacet);
+        assert(triangulation().tds().is_facet(facet.first, facet.second));
+        init_faces.emplace_back(facet);
       }
       assert(init_faces.size() == triangulation().number_of_finite_facets());
       return init_faces;
     }  // collect_faces
-
-    /// @return Container of all the finite edges in the triangulation
-    [[nodiscard]] auto collect_edges() const -> Edge_container
-    {
-      assert(is_tds_valid());
-      Edge_container init_edges;
-      init_edges.reserve(number_of_finite_edges());
-      for (auto eit = triangulation().finite_edges_begin();
-           eit != triangulation().finite_edges_end(); ++eit)
-      {
-        Cell_handle_t<3> const cell = eit->first;
-        Edge_handle_t<3> const thisEdge{cell,
-                                        cell->index(cell->vertex(eit->second)),
-                                        cell->index(cell->vertex(eit->third))};
-        // Each edge is valid in the triangulation
-        assert(triangulation().tds().is_valid(thisEdge.first, thisEdge.second,
-                                              thisEdge.third));
-        init_edges.emplace_back(thisEdge);
-      }
-      assert(init_edges.size() == number_of_finite_edges());
-      return init_edges;
-    }  // collect_edges
   };
 
   using FoliatedTriangulation_3 = FoliatedTriangulation<3>;

--- a/include/Manifold.hpp
+++ b/include/Manifold.hpp
@@ -196,9 +196,18 @@ namespace cdt::manifolds
     [[nodiscard]] auto is_valid() const -> bool
     { return m_triangulation.is_tds_valid(); }  // is_valid
 
-    /// @returns If base data structures are correct
+    /// @returns Whether essential structural and causal invariants hold
+    [[nodiscard]] auto is_structurally_correct() const -> bool
+    { return m_triangulation.is_structurally_correct(); }
+
+    /// @returns Whether essential base-data invariants hold
     [[nodiscard]] auto is_correct() const -> bool
-    { return m_triangulation.is_correct(); }  // is_correct
+    { return is_structurally_correct(); }  // is_correct
+
+    /// @returns Whether all invariants and derived caches are consistent
+    /// @details This opt-in diagnostic performs cache-rebuilding scans.
+    [[nodiscard]] auto is_correct_with_diagnostics() const -> bool
+    { return m_triangulation.is_correct_with_diagnostics(); }
 
     /// @returns Run-time dimensionality of the triangulation data structure
     [[nodiscard]] auto dimensionality() const

--- a/include/Settings.hpp
+++ b/include/Settings.hpp
@@ -35,8 +35,6 @@ namespace cdt
 #define CDT_PRETTY_FUNCTION __PRETTY_FUNCTION__
 #endif
 
-  // #define CGAL_LINKED_WITH_TBB
-
   /// Correctly declare global constants
   /// See Jonathan Boccara's C++ Pitfalls, January 2021
 

--- a/include/Triangulation_traits.hpp
+++ b/include/Triangulation_traits.hpp
@@ -12,10 +12,16 @@
 #define CDT_PLUSPLUS_TRIANGULATION_TRAITS_HPP
 
 #include <CGAL/Delaunay_triangulation_3.h>
+#include <CGAL/Delaunay_triangulation_cell_base_3.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/point_generators_3.h>
+#include <CGAL/tags.h>
 #include <CGAL/Triangulation_cell_base_with_info_3.h>
+#include <CGAL/Triangulation_data_structure_3.h>
 #include <CGAL/Triangulation_vertex_base_with_info_3.h>
+
+#include <utility>
+#include <vector>
 
 #include "Settings.hpp"
 
@@ -30,20 +36,26 @@ namespace cdt::detail
     using Kernel = CGAL::Exact_predicates_inexact_constructions_kernel;
     using Vertex_base =
         CGAL::Triangulation_vertex_base_with_info_3<Int_precision, Kernel>;
+    using Delaunay_cell_base = CGAL::Delaunay_triangulation_cell_base_3<Kernel>;
     using Cell_base =
-        CGAL::Triangulation_cell_base_with_info_3<Int_precision, Kernel>;
-#ifdef CGAL_LINKED_WITH_TBB
-    using Tds = CGAL::Triangulation_data_structure_3<Vertex_base, Cell_base,
-                                                     CGAL::Parallel_tag>;
-#else
-    using Tds = CGAL::Triangulation_data_structure_3<Vertex_base, Cell_base>;
+        CGAL::Triangulation_cell_base_with_info_3<Int_precision, Kernel,
+                                                  Delaunay_cell_base>;
+#if defined(CDT_ENABLE_PARALLEL_TRIANGULATION) && \
+    CDT_ENABLE_PARALLEL_TRIANGULATION
+#ifndef CGAL_LINKED_WITH_TBB
+#error "Parallel CDT++ triangulations require CGAL::TBB_support."
 #endif
-    using Delaunay    = CGAL::Delaunay_triangulation_3<Kernel, Tds>;
+    using Concurrency_tag = CGAL::Parallel_tag;
+#else
+    using Concurrency_tag = CGAL::Sequential_tag;
+#endif
+    using Tds = CGAL::Triangulation_data_structure_3<Vertex_base, Cell_base,
+                                                     Concurrency_tag>;
+    using Delaunay         = CGAL::Delaunay_triangulation_3<Kernel, Tds>;
 
-    using Cell_handle = Delaunay::Cell_handle;
-    using Face_handle = std::pair<Cell_handle, Int_precision>;
-    using Facet       = Delaunay::Facet;
-    using Edge_handle = CGAL::Triple<Cell_handle, Int_precision, Int_precision>;
+    using Cell_handle      = Delaunay::Cell_handle;
+    using Facet            = Delaunay::Facet;
+    using Edge_handle      = Delaunay::Edge;
     using Vertex_handle    = Delaunay::Vertex_handle;
     using Point            = Delaunay::Point;
     using Causal_vertices  = std::vector<std::pair<Point, Int_precision>>;

--- a/include/Utilities.hpp
+++ b/include/Utilities.hpp
@@ -234,10 +234,8 @@ namespace cdt::utilities
     template <typename TriangulationType>
     inline bool constexpr HAS_CAUSAL_INFO =
         requires(TriangulationType const& triangulation) {
-          triangulation.finite_vertices_begin();
-          triangulation.finite_vertices_end();
-          triangulation.finite_cells_begin();
-          triangulation.finite_cells_end();
+          triangulation.finite_vertex_handles();
+          triangulation.finite_cell_handles();
           triangulation.number_of_vertices();
           triangulation.number_of_finite_cells();
         };
@@ -249,8 +247,7 @@ namespace cdt::utilities
       std::vector<std::string> records;
       records.reserve(
           static_cast<std::size_t>(triangulation.number_of_vertices()));
-      for (auto vertex = triangulation.finite_vertices_begin();
-           vertex != triangulation.finite_vertices_end(); ++vertex)
+      for (auto const vertex : triangulation.finite_vertex_handles())
       {
         records.emplace_back(
             fmt::format("v:{}:{}", point_key(vertex->point()), vertex->info()));
@@ -289,8 +286,7 @@ namespace cdt::utilities
       records.reserve(
           static_cast<std::size_t>(triangulation.number_of_vertices() +
                                    triangulation.number_of_finite_cells()));
-      for (auto cell = triangulation.finite_cells_begin();
-           cell != triangulation.finite_cells_end(); ++cell)
+      for (auto const cell : triangulation.finite_cell_handles())
       {
         records.emplace_back(
             fmt::format("c:{}:{}", cell_key(cell), cell->info()));
@@ -308,8 +304,7 @@ namespace cdt::utilities
         std::vector<std::string> vertices;
         vertices.reserve(
             static_cast<std::size_t>(triangulation.number_of_vertices()));
-        for (auto vertex = triangulation.finite_vertices_begin();
-             vertex != triangulation.finite_vertices_end(); ++vertex)
+        for (auto const vertex : triangulation.finite_vertex_handles())
         {
           vertices.emplace_back(
               fmt::format("{}|{}", point_key(vertex->point()), vertex->info()));
@@ -319,8 +314,7 @@ namespace cdt::utilities
         std::vector<std::string> cells;
         cells.reserve(
             static_cast<std::size_t>(triangulation.number_of_finite_cells()));
-        for (auto cell = triangulation.finite_cells_begin();
-             cell != triangulation.finite_cells_end(); ++cell)
+        for (auto const cell : triangulation.finite_cell_handles())
         {
           cells.emplace_back(
               fmt::format("{}|{}", cell_key(cell), cell->info()));
@@ -608,8 +602,7 @@ namespace cdt::utilities
         }
       }
 
-      for (auto vertex = triangulation.finite_vertices_begin();
-           vertex != triangulation.finite_vertices_end(); ++vertex)
+      for (auto const vertex : triangulation.finite_vertex_handles())
       {
         auto const found = vertex_info.find(point_key(vertex->point()));
         if (found == vertex_info.end())
@@ -621,8 +614,7 @@ namespace cdt::utilities
         vertex->info() = found->second;
         vertex_info.erase(found);
       }
-      for (auto cell = triangulation.finite_cells_begin();
-           cell != triangulation.finite_cells_end(); ++cell)
+      for (auto const cell : triangulation.finite_cell_handles())
       {
         auto const found = cell_info.find(cell_key(cell));
         if (found == cell_info.end())
@@ -1113,11 +1105,11 @@ namespace cdt::utilities
         }
         else
         {
-          auto vertex            = triangulation.finite_vertices_begin();
-          auto minimum_timeslice = static_cast<Int_precision>(vertex->info());
+          auto const vertices    = triangulation.finite_vertex_handles();
+          auto const first       = vertices.begin();
+          auto minimum_timeslice = static_cast<Int_precision>((*first)->info());
           auto maximum_timeslice = minimum_timeslice;
-          for (++vertex; vertex != triangulation.finite_vertices_end();
-               ++vertex)
+          for (auto const vertex : vertices)
           {
             auto const time   = static_cast<Int_precision>(vertex->info());
             minimum_timeslice = std::min(minimum_timeslice, time);

--- a/scripts/clang-tidy.sh
+++ b/scripts/clang-tidy.sh
@@ -9,20 +9,14 @@ script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "${script_dir}/.." && pwd)"
 build_dir="${repo_root}/build"
 if ! command -v just >/dev/null; then
-  echo "just is required to resolve repository tool versions; run this through 'just clang-tidy'." >&2
+  echo "just is required to resolve the repository LLVM version; run 'just clang-tidy'." >&2
   exit 1
 fi
-just_version="$(just --justfile "${repo_root}/Justfile" --evaluate just_version)"
 llvm_version="$(just --justfile "${repo_root}/Justfile" --evaluate llvm_version)"
 clang_tidy_vcpkg_installed_dir="${repo_root}/.cache/vcpkg-installed/clang-tidy-llvm-${llvm_version}"
 
-if [[ "${CDT_CLANG_TIDY_ACTIVE:-0}" != 1 ]] && command -v pkgx >/dev/null; then
-  export CDT_CLANG_TIDY_ACTIVE=1
-  exec pkgx "+just.systems@${just_version}" "+llvm.org@${llvm_version}" +cmake.org +ninja-build.org -- "${BASH_SOURCE[0]}" "$@"
-fi
-
 command -v clang-tidy >/dev/null || {
-  echo "clang-tidy ${llvm_version} is required; install it or install pkgx." >&2
+  echo "clang-tidy ${llvm_version} is required; run this through 'just clang-tidy'." >&2
   exit 1
 }
 clang-tidy --version | grep -Eq "LLVM version ${llvm_version}([.]|$)" || {
@@ -31,6 +25,7 @@ clang-tidy --version | grep -Eq "LLVM version ${llvm_version}([.]|$)" || {
 }
 
 source "${script_dir}/prepare-vcpkg.sh"
+prepare_reference_environment
 prepare_vcpkg "${repo_root}"
 
 rm -rf -- "${build_dir}"

--- a/scripts/slurm.sh
+++ b/scripts/slurm.sh
@@ -10,7 +10,7 @@ repo_root="$(cd -- "${script_dir}/.." && pwd)"
 build_dir="${repo_root}/build"
 
 module load cmake/3.28.1
-module load gcc/13.2.0
+module load gcc/13.3.0
 module load autoconf-archive/2022.02.11
 rm -rf -- "${build_dir}"
 cmake -D CMAKE_BUILD_TYPE=RelWithDebInfo -D ENABLE_TESTING:BOOL=TRUE -S "${repo_root}" -B "${build_dir}"

--- a/tests/Apply_move_test.cpp
+++ b/tests/Apply_move_test.cpp
@@ -75,6 +75,7 @@ namespace
   {
     CHECK(before.is_correct());
     CHECK(after.is_correct());
+    CHECK(after.is_correct_with_diagnostics());
     CHECK(ergodic_moves::detail::check_move(before, after, move));
   }
 }  // namespace

--- a/tests/CGAL_benchmark.cpp
+++ b/tests/CGAL_benchmark.cpp
@@ -1,0 +1,260 @@
+/*******************************************************************************
+ Causal Dynamical Triangulations in C++ using CGAL
+
+ Copyright © 2026 Adam Getchell
+ ******************************************************************************/
+
+/// @file CGAL_benchmark.cpp
+/// @brief Repeatable diagnostics for the production CGAL integration boundary
+
+#include <CGAL/version.h>
+
+#include <algorithm>
+#include <array>
+#include <charconv>
+#include <chrono>
+#include <concepts>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <gsl/narrow>
+#include <iostream>
+#include <iterator>
+#include <ranges>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "Manifold.hpp"
+#include "Move_command.hpp"
+
+namespace
+{
+  using Clock       = std::chrono::steady_clock;
+  using Nanoseconds = std::chrono::nanoseconds;
+  using Manifold    = cdt::manifolds::Manifold_3;
+
+  struct Topology_counts
+  {
+    cdt::Int_precision vertices{};
+    cdt::Int_precision cells{};
+  };
+
+  struct Measurements
+  {
+    std::vector<std::int64_t> samples;
+
+    void                      add(Nanoseconds const duration)
+    { samples.push_back(duration.count()); }
+
+    void print(std::string_view const name) const
+    {
+      auto ordered = samples;
+      std::ranges::sort(ordered);
+      std::cout << name << "_ns_min=" << ordered.front() << '\n'
+                << name << "_ns_median=" << ordered[ordered.size() / 2] << '\n'
+                << name << "_ns_max=" << ordered.back() << '\n';
+    }
+  };
+
+  [[nodiscard]] auto parse_positive(char const*            argument,
+                                    std::string_view const name)
+      -> cdt::Int_precision
+  {
+    cdt::Int_precision value{};
+    auto const         text = std::string_view{argument};
+    auto const [end, error] =
+        std::from_chars(text.data(), text.data() + text.size(), value);
+    if (error != std::errc{} || end != text.data() + text.size() || value <= 0)
+    {
+      throw std::invalid_argument{std::string{name} +
+                                  " must be a positive integer"};
+    }
+    return value;
+  }
+
+  template <typename Operation>
+  [[nodiscard]] auto measure(Operation&& operation)
+  {
+    auto const start  = Clock::now();
+    auto       result = std::invoke(std::forward<Operation>(operation));
+    auto const elapsed =
+        std::chrono::duration_cast<Nanoseconds>(Clock::now() - start);
+    return std::pair{elapsed, std::move(result)};
+  }
+
+  [[nodiscard]] auto repair(cdt::Delaunay_t<3>& triangulation) -> std::size_t
+  {
+    std::size_t passes{};
+    auto const  repeat = [&](auto&& operation) {
+      for (auto attempt = 0; attempt < cdt::detail::MAX_FIX_PASSES; ++attempt)
+      {
+        if (!std::invoke(operation)) { return; }
+        ++passes;
+      }
+    };
+    repeat([&] {
+      return cdt::foliated_triangulations::fix_vertices<3>(
+          triangulation, cdt::INITIAL_RADIUS, cdt::FOLIATION_SPACING);
+    });
+    repeat([&] {
+      return cdt::foliated_triangulations::fix_timevalues<3>(triangulation);
+    });
+    repeat([&] {
+      return cdt::foliated_triangulations::fix_cells<3>(triangulation);
+    });
+    return passes;
+  }
+
+  [[nodiscard]] auto checksum_component(std::integral auto const value)
+      -> std::uint64_t
+  { return gsl::narrow<std::uint64_t>(value); }
+}  // namespace
+
+auto main(int const argc, char const* const argv[]) -> int
+try
+{
+  if (argc > 4)
+  {
+    throw std::invalid_argument{
+        "usage: CDT_cgal_benchmark [simplices] [repetitions] [moves]"};
+  }
+  auto const simplices = argc > 1 ? parse_positive(argv[1], "simplices") : 640;
+  auto const repetitions =
+      argc > 2 ? parse_positive(argv[2], "repetitions") : 5;
+  auto const move_count     = argc > 3 ? parse_positive(argv[3], "moves") : 50;
+  auto constexpr timeslices = cdt::Int_precision{4};
+
+  cdt::Random input_random{102};
+  auto const  input = cdt::foliated_triangulations::make_foliated_ball<3>(
+      simplices, timeslices, cdt::INITIAL_RADIUS, cdt::FOLIATION_SPACING,
+      input_random);
+
+  Measurements       bulk_insert;
+  Measurements       foliation_repair;
+  Measurements       cache_rebuild;
+  Measurements       point_lookup;
+  Measurements       snapshot_copy;
+  Measurements       vertex_removal;
+  Measurements       move_workload;
+  std::uint64_t      checksum{};
+  cdt::Int_precision final_vertices{};
+  cdt::Int_precision final_cells{};
+
+  for (cdt::Int_precision repetition = 0; repetition < repetitions;
+       ++repetition)
+  {
+    auto [insert_time, state] =
+        measure([&input] { return cdt::detail::Delaunay_state<3>{input}; });
+    bulk_insert.add(insert_time);
+
+    auto [repair_time, repair_passes] = measure(
+        [&state] { return repair(state.mutable_triangulation_unchecked()); });
+    foliation_repair.add(repair_time);
+
+    auto detached = std::move(state).into_detached_triangulation();
+    auto [cache_time, manifold] = measure([&detached] {
+      return Manifold{cdt::foliated_triangulations::FoliatedTriangulation_3{
+          std::move(detached)}};
+    });
+    cache_rebuild.add(cache_time);
+    if (!manifold.is_correct())
+    {
+      throw std::runtime_error{
+          "benchmark construction violated CDT invariants"};
+    }
+
+    auto [copy_time, snapshot] =
+        measure([&manifold] { return manifold.delaunay_snapshot(); });
+    snapshot_copy.add(copy_time);
+
+    std::vector<cdt::Point_t<3>> points;
+    points.reserve(snapshot.number_of_vertices());
+    std::ranges::transform(snapshot.finite_vertex_handles(),
+                           std::back_inserter(points),
+                           [](auto const vertex) { return vertex->point(); });
+    auto [lookup_time, found] = measure([&snapshot, &points] {
+      return std::ranges::count_if(points, [&snapshot](auto const& point) {
+        return cdt::foliated_triangulations::find_vertex<3>(snapshot, point)
+            .has_value();
+      });
+    });
+    point_lookup.add(lookup_time);
+
+    std::vector<cdt::Vertex_handle_t<3>> to_remove;
+    auto const                           removal_count =
+        std::max<std::size_t>(1, snapshot.number_of_vertices() / 16);
+    to_remove.reserve(removal_count);
+    for (auto const vertex :
+         snapshot.finite_vertex_handles() | std::views::take(removal_count))
+    {
+      to_remove.push_back(vertex);
+    }
+    auto [remove_time, removed] = measure([&snapshot, &to_remove] {
+      return snapshot.remove(to_remove.begin(), to_remove.end());
+    });
+    vertex_removal.add(remove_time);
+    if (!snapshot.is_valid())
+    {
+      throw std::runtime_error{"benchmark removal invalidated the CGAL TDS"};
+    }
+
+    cdt::MoveCommand<Manifold> command{manifold};
+    auto constexpr moves = std::array{
+        cdt::move_tracker::move_type::TWO_THREE,
+        cdt::move_tracker::move_type::THREE_TWO,
+        cdt::move_tracker::move_type::TWO_SIX,
+        cdt::move_tracker::move_type::SIX_TWO,
+        cdt::move_tracker::move_type::FOUR_FOUR,
+    };
+    for (cdt::Int_precision index = 0; index < move_count; ++index)
+    {
+      command.enqueue(moves[static_cast<std::size_t>(index) % moves.size()]);
+    }
+    cdt::Random move_random{102};
+    auto [moves_time, final_topology] = measure([&command, &move_random] {
+      command.execute(move_random);
+      auto const& result = command.get_const_results();
+      return Topology_counts{result.N0(), result.N3()};
+    });
+    move_workload.add(moves_time);
+    if (!command.get_const_results().is_correct())
+    {
+      throw std::runtime_error{
+          "benchmark move workload violated CDT invariants"};
+    }
+
+    final_vertices = final_topology.vertices;
+    final_cells    = final_topology.cells;
+    checksum += checksum_component(repair_passes) + checksum_component(found) +
+                checksum_component(removed) +
+                checksum_component(final_vertices) +
+                checksum_component(final_cells);
+  }
+
+  std::cout << "cgal_version=" << CGAL_VERSION_STR << '\n'
+            << "parallel_tds=" << CDT_ENABLE_PARALLEL_TRIANGULATION << '\n'
+            << "requested_simplices=" << simplices << '\n'
+            << "timeslices=" << timeslices << '\n'
+            << "generated_points=" << input.size() << '\n'
+            << "repetitions=" << repetitions << '\n'
+            << "moves_per_repetition=" << move_count << '\n'
+            << "final_vertices=" << final_vertices << '\n'
+            << "final_cells=" << final_cells << '\n'
+            << "checksum=" << checksum << '\n';
+  bulk_insert.print("bulk_insert");
+  foliation_repair.print("foliation_repair");
+  cache_rebuild.print("cache_rebuild");
+  point_lookup.print("point_lookup");
+  snapshot_copy.print("snapshot_copy");
+  vertex_removal.print("vertex_removal");
+  move_workload.print("move_workload");
+  return 0;
+}
+catch (std::exception const& error)
+{
+  std::cerr << "CGAL benchmark: " << error.what() << '\n';
+  return 2;
+}

--- a/tests/CGAL_integration_test.cpp
+++ b/tests/CGAL_integration_test.cpp
@@ -1,0 +1,191 @@
+/*******************************************************************************
+ Causal Dynamical Triangulations in C++ using CGAL
+
+ Copyright © 2026 Adam Getchell
+ ******************************************************************************/
+
+/// @file CGAL_integration_test.cpp
+/// @brief CGAL 6.2 integration, metadata, and robustness contracts
+
+#include <CGAL/enum.h>
+#include <CGAL/kernel_basic.h>
+#include <CGAL/version.h>
+#include <doctest/doctest.h>
+
+#include <concepts>
+#include <limits>
+#include <ranges>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "Foliated_triangulation.hpp"
+
+namespace
+{
+  using Traits   = cdt::detail::TriangulationTraits<3>;
+  using Delaunay = cdt::Delaunay_t<3>;
+  using Point    = cdt::Point_t<3>;
+
+  struct Mutable_only_forward_range
+  {
+    std::vector<int>   values;
+
+    [[nodiscard]] auto begin() { return values.begin(); }
+    [[nodiscard]] auto end() { return values.end(); }
+  };
+
+  static_assert(std::ranges::forward_range<Mutable_only_forward_range>);
+  static_assert(!cdt::detail::ConstForwardRange<Mutable_only_forward_range>);
+  static_assert(cdt::detail::ConstForwardRange<std::vector<int>>);
+
+#if defined(CDT_ENABLE_PARALLEL_TRIANGULATION) && \
+    CDT_ENABLE_PARALLEL_TRIANGULATION
+  using Expected_concurrency_tag = CGAL::Parallel_tag;
+#else
+  using Expected_concurrency_tag = CGAL::Sequential_tag;
+#endif
+
+  static_assert(CGAL_VERSION_MAJOR == 6);
+  static_assert(CGAL_VERSION_MINOR == 2);
+  static_assert(std::same_as<cdt::Facet_t<3>, Delaunay::Facet>);
+  static_assert(std::same_as<cdt::Edge_handle_t<3>, Delaunay::Edge>);
+  static_assert(
+      std::same_as<Traits::Tds::Concurrency_tag, Expected_concurrency_tag>);
+  static_assert(
+      std::same_as<decltype(std::declval<Traits::Vertex_base&>().info()),
+                   cdt::Int_precision&>);
+  static_assert(
+      std::same_as<decltype(std::declval<Traits::Cell_base&>().info()),
+                   cdt::Int_precision&>);
+  static_assert(requires(Traits::Cell_base const& cell) {
+    { cell.circumcenter() } -> std::same_as<Point>;
+  });
+
+  [[nodiscard]] auto labelled_points() -> cdt::Causal_vertices_t<3>
+  {
+    return {
+        {Point{0.0, 0.0, 0.0}, 17},
+        {Point{1.0, 0.0, 0.0},  5},
+        {Point{0.0, 1.0, 0.0}, 11},
+        {Point{0.0, 0.0, 1.0},  3},
+        {Point{1.0, 1.0, 1.0}, 23},
+    };
+  }
+}  // namespace
+
+SCENARIO("CGAL bulk insertion preserves point metadata" *
+         doctest::test_suite("cgal_integration"))
+{
+  GIVEN("Distinct point and timevalue pairs in non-canonical order.")
+  {
+    auto const input = labelled_points();
+
+    WHEN("CGAL spatially sorts and inserts the range.")
+    {
+      cdt::detail::Delaunay_state<3> const state{input};
+
+      THEN("Every geometric point retains its original timevalue.")
+      {
+        REQUIRE_EQ(state.triangulation().number_of_vertices(), input.size());
+        for (auto const& labelled_point : input)
+        {
+          auto const& point     = labelled_point.first;
+          auto const  timevalue = labelled_point.second;
+          auto const  vertex    = cdt::foliated_triangulations::find_vertex<3>(
+              state.triangulation(), point);
+          REQUIRE(vertex.has_value());
+          CHECK_EQ(vertex.value()->info(), timevalue);
+        }
+      }
+    }
+  }
+}
+
+SCENARIO("CGAL insertion rejects ambiguous boundary metadata" *
+         doctest::test_suite("cgal_integration"))
+{
+  GIVEN("Two timevalues attached to the same geometric point.")
+  {
+    cdt::Causal_vertices_t<3> const duplicates{
+        {Point{1.0, 2.0, 3.0}, 1},
+        {Point{1.0, 2.0, 3.0}, 2},
+    };
+
+    THEN("The invariant-bearing triangulation state rejects the range.")
+    {
+      CHECK_THROWS_AS(cdt::detail::Delaunay_state<3>{duplicates},
+                      std::invalid_argument);
+    }
+  }
+
+  GIVEN("A timevalue wider than the repository integer contract.")
+  {
+    std::vector<Point> const points{
+        Point{1.0, 0.0, 0.0}
+    };
+    std::vector<std::size_t> const timevalues{
+        static_cast<std::size_t>(
+            std::numeric_limits<cdt::Int_precision>::max()) +
+        std::size_t{1}};
+
+    THEN("Pair construction rejects the narrowing conversion.")
+    {
+      CHECK_THROWS_AS(cdt::foliated_triangulations::make_causal_vertices<3>(
+                          points, timevalues),
+                      std::out_of_range);
+    }
+  }
+}
+
+SCENARIO("EPICK resolves adversarial orientation and co-spherical input" *
+         doctest::test_suite("cgal_integration"))
+{
+  GIVEN("A tetrahedron whose fourth vertex is almost coplanar.")
+  {
+    Point const origin{0.0, 0.0, 0.0};
+    Point const x_axis{1.0, 0.0, 0.0};
+    Point const y_axis{0.0, 1.0, 0.0};
+    Point const above_plane{1.0e-150, 1.0e-150, 1.0e-300};
+
+    THEN("The exact orientation predicate retains the analytic sign.")
+    {
+      CHECK_EQ(CGAL::orientation(origin, x_axis, y_axis, above_plane),
+               CGAL::POSITIVE);
+    }
+  }
+
+  GIVEN("Six points on one exact sphere.")
+  {
+    cdt::Causal_vertices_t<3> const cospherical{
+        { Point{1.0, 0.0, 0.0}, 1},
+        {Point{-1.0, 0.0, 0.0}, 1},
+        { Point{0.0, 1.0, 0.0}, 2},
+        {Point{0.0, -1.0, 0.0}, 2},
+        { Point{0.0, 0.0, 1.0}, 3},
+        {Point{0.0, 0.0, -1.0}, 3},
+    };
+
+    WHEN("The points are inserted through the supported CGAL path.")
+    {
+      cdt::detail::Delaunay_state<3> const state{cospherical};
+
+      THEN("CGAL chooses a valid representative without losing labels.")
+      {
+        CHECK_EQ(state.triangulation().number_of_vertices(),
+                 cospherical.size());
+        CHECK(state.triangulation().is_valid());
+        for (auto const& labelled_point : cospherical)
+        {
+          auto const& point     = labelled_point.first;
+          auto const  timevalue = labelled_point.second;
+          auto const  vertex    = cdt::foliated_triangulations::find_vertex<3>(
+              state.triangulation(), point);
+          REQUIRE(vertex.has_value());
+          CHECK_EQ(vertex.value()->info(), timevalue);
+        }
+      }
+    }
+  }
+}

--- a/tests/CGAL_integration_test.cpp
+++ b/tests/CGAL_integration_test.cpp
@@ -20,6 +20,7 @@
 #include <utility>
 #include <vector>
 
+#include "CGAL_test_helpers.hpp"
 #include "Foliated_triangulation.hpp"
 
 namespace
@@ -89,15 +90,8 @@ SCENARIO("CGAL bulk insertion preserves point metadata" *
       THEN("Every geometric point retains its original timevalue.")
       {
         REQUIRE_EQ(state.triangulation().number_of_vertices(), input.size());
-        for (auto const& labelled_point : input)
-        {
-          auto const& point     = labelled_point.first;
-          auto const  timevalue = labelled_point.second;
-          auto const  vertex    = cdt::foliated_triangulations::find_vertex<3>(
-              state.triangulation(), point);
-          REQUIRE(vertex.has_value());
-          CHECK_EQ(vertex.value()->info(), timevalue);
-        }
+        cdt::test_helpers::expect_labels_preserved(state.triangulation(),
+                                                   input);
       }
     }
   }
@@ -176,15 +170,8 @@ SCENARIO("EPICK resolves adversarial orientation and co-spherical input" *
         CHECK_EQ(state.triangulation().number_of_vertices(),
                  cospherical.size());
         CHECK(state.triangulation().is_valid());
-        for (auto const& labelled_point : cospherical)
-        {
-          auto const& point     = labelled_point.first;
-          auto const  timevalue = labelled_point.second;
-          auto const  vertex    = cdt::foliated_triangulations::find_vertex<3>(
-              state.triangulation(), point);
-          REQUIRE(vertex.has_value());
-          CHECK_EQ(vertex.value()->info(), timevalue);
-        }
+        cdt::test_helpers::expect_labels_preserved(state.triangulation(),
+                                                   cospherical);
       }
     }
   }

--- a/tests/CGAL_test_helpers.hpp
+++ b/tests/CGAL_test_helpers.hpp
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ Causal Dynamical Triangulations in C++ using CGAL
+
+ Copyright © 2026 Adam Getchell
+ ******************************************************************************/
+
+/// @file CGAL_test_helpers.hpp
+/// @brief Shared assertions for CGAL integration tests
+
+#ifndef CDT_PLUSPLUS_CGAL_TEST_HELPERS_HPP
+#define CDT_PLUSPLUS_CGAL_TEST_HELPERS_HPP
+
+#include <doctest/doctest.h>
+
+#include "Foliated_triangulation.hpp"
+
+namespace cdt::test_helpers
+{
+  inline void expect_labels_preserved(
+      Delaunay_t<3> const&        triangulation,
+      Causal_vertices_t<3> const& labelled_points)
+  {
+    for (auto const& [point, expected_label] : labelled_points)
+    {
+      auto const vertex =
+          foliated_triangulations::find_vertex<3>(triangulation, point);
+      REQUIRE_MESSAGE(vertex.has_value(),
+                      "Expected labelled point is missing from triangulation.");
+      CHECK_EQ(vertex.value()->info(), expected_label);
+    }
+  }
+}  // namespace cdt::test_helpers
+
+#endif  // CDT_PLUSPLUS_CGAL_TEST_HELPERS_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(
   ${PROJECT_SOURCE_DIR}/tests/main.cpp
   Apply_move_test.cpp
   Bistellar_flip_test.cpp
+  CGAL_integration_test.cpp
   Ergodic_moves_3_audit_test.cpp
   Ergodic_moves_3_test.cpp
   Foliated_triangulation_test.cpp
@@ -127,6 +128,19 @@ target_link_libraries(
           date::date-tz
           fmt::fmt-header-only
           spdlog::spdlog_header_only)
+
+# Keep the issue #102 integration benchmark buildable without registering it
+# as a correctness or performance test. Run it through `just benchmark-cgal`.
+add_executable(CDT_cgal_benchmark CGAL_benchmark.cpp)
+target_compile_features(CDT_cgal_benchmark PRIVATE cxx_std_23)
+target_link_libraries(
+  CDT_cgal_benchmark
+  PRIVATE project_options
+          project_warnings
+          date::date-tz
+          fmt::fmt-header-only
+          spdlog::spdlog_header_only
+          CGAL::CGAL)
 
 # Run unit tests
 add_test(NAME cdt-unit-tests COMMAND $<TARGET_FILE:CDT_unit_tests>)

--- a/tests/Parallel_triangulation_test.cpp
+++ b/tests/Parallel_triangulation_test.cpp
@@ -11,6 +11,7 @@
 
 #include <atomic>
 #include <concepts>
+#include <gsl/util>
 #include <latch>
 #include <random>
 #include <ranges>
@@ -19,6 +20,7 @@
 #include <utility>
 #include <vector>
 
+#include "CGAL_test_helpers.hpp"
 #include "Foliated_triangulation.hpp"
 
 using namespace cdt;
@@ -73,15 +75,7 @@ TEST_CASE("CGAL parallel insertion and removal retain their lock-grid owner" *
           detail::locking_box<3>(vertices));
     REQUIRE(state.triangulation().number_of_vertices() > 100);
     REQUIRE(state.triangulation().is_valid());
-    for (auto const& labelled_point : vertices)
-    {
-      auto const& point     = labelled_point.first;
-      auto const  timevalue = labelled_point.second;
-      auto const  vertex =
-          foliated_triangulations::find_vertex<3>(state.triangulation(), point);
-      REQUIRE(vertex);
-      CHECK_EQ((*vertex)->info(), timevalue);
-    }
+    test_helpers::expect_labels_preserved(state.triangulation(), vertices);
 
     detail::Delaunay_state<3> const copied{state};
     REQUIRE(copied.lock_data_structure() != nullptr);
@@ -136,46 +130,54 @@ TEST_CASE("A failed concurrent lock leaves the triangulation unchanged" *
   auto* const lock_grid     = state.lock_data_structure();
   REQUIRE(lock_grid != nullptr);
 
-  Point_t<3> const candidate{0.125, 0.25, 0.375};
   auto const       start = *triangulation.finite_cell_handles().begin();
   auto const       contested_point = start->vertex(0)->point();
+  Point_t<3> const candidate{contested_point.x() + 0.01,
+                             contested_point.y() + 0.01,
+                             contested_point.z() + 0.01};
+  REQUIRE(lock_grid->check_if_all_tls_cells_are_unlocked());
   REQUIRE(lock_grid->template try_lock<true>(contested_point));
+  REQUIRE_MESSAGE(
+      lock_grid->is_locked_by_this_thread(candidate),
+      "Contention fixture requires candidate and contested_point to share a "
+      "lock-grid cell; update them when LOCK_GRID_RESOLUTION or "
+      "GV_BOUNDING_BOX_SIZE changes.");
   lock_grid->unlock_all_points_locked_by_this_thread();
 
-  std::latch       locked{1};
-  std::latch       release{1};
-  std::atomic_bool lock_acquired{false};
-  std::jthread     holder{[&] {
-    lock_acquired.store(lock_grid->template try_lock<true>(contested_point));
-    locked.count_down();
-    release.wait();
-    lock_grid->unlock_all_points_locked_by_this_thread();
-  }};
-  locked.wait();
-  if (!lock_acquired.load())
   {
-    release.count_down();
-    holder.join();
-    FAIL_CHECK("The fixture thread could not acquire the candidate lock.");
-    return;
+    std::latch                  locked{1};
+    std::latch                  release{1};
+    std::atomic_bool            lock_acquired{false};
+    std::jthread                holder{[&] {
+      lock_acquired.store(lock_grid->template try_lock<true>(contested_point));
+      locked.count_down();
+      release.wait();
+      lock_grid->unlock_all_points_locked_by_this_thread();
+    }};
+    [[maybe_unused]] auto const release_holder =
+        gsl::finally([&release] { release.count_down(); });
+    locked.wait();
+    if (!lock_acquired.load())
+    {
+      FAIL_CHECK("The fixture thread could not acquire the candidate lock.");
+      return;
+    }
+
+    auto const vertices_before = triangulation.number_of_vertices();
+    auto const cells_before    = triangulation.number_of_finite_cells();
+    bool       could_lock_zone = true;
+    auto const inserted =
+        triangulation.insert(candidate, start, &could_lock_zone);
+
+    CHECK_FALSE(could_lock_zone);
+    CHECK(inserted == Vertex_handle_t<3>{});
+    CHECK_EQ(triangulation.number_of_vertices(), vertices_before);
+    CHECK_EQ(triangulation.number_of_finite_cells(), cells_before);
+    CHECK_FALSE(find_vertex<3>(triangulation, candidate));
+    CHECK(triangulation.is_valid());
+
+    triangulation.unlock_all_elements();
   }
-
-  auto const vertices_before = triangulation.number_of_vertices();
-  auto const cells_before    = triangulation.number_of_finite_cells();
-  bool       could_lock_zone = true;
-  auto const inserted =
-      triangulation.insert(candidate, start, &could_lock_zone);
-
-  CHECK_FALSE(could_lock_zone);
-  CHECK(inserted == Vertex_handle_t<3>{});
-  CHECK_EQ(triangulation.number_of_vertices(), vertices_before);
-  CHECK_EQ(triangulation.number_of_finite_cells(), cells_before);
-  CHECK_FALSE(find_vertex<3>(triangulation, candidate));
-  CHECK(triangulation.is_valid());
-
-  triangulation.unlock_all_elements();
-  release.count_down();
-  holder.join();
   CHECK(lock_grid->check_if_all_cells_are_unlocked());
 }
 

--- a/tests/Parallel_triangulation_test.cpp
+++ b/tests/Parallel_triangulation_test.cpp
@@ -9,8 +9,12 @@
 
 #include <doctest/doctest.h>
 
+#include <atomic>
 #include <concepts>
+#include <latch>
 #include <random>
+#include <ranges>
+#include <thread>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -69,6 +73,15 @@ TEST_CASE("CGAL parallel insertion and removal retain their lock-grid owner" *
           detail::locking_box<3>(vertices));
     REQUIRE(state.triangulation().number_of_vertices() > 100);
     REQUIRE(state.triangulation().is_valid());
+    for (auto const& labelled_point : vertices)
+    {
+      auto const& point     = labelled_point.first;
+      auto const  timevalue = labelled_point.second;
+      auto const  vertex =
+          foliated_triangulations::find_vertex<3>(state.triangulation(), point);
+      REQUIRE(vertex);
+      CHECK_EQ((*vertex)->info(), timevalue);
+    }
 
     detail::Delaunay_state<3> const copied{state};
     REQUIRE(copied.lock_data_structure() != nullptr);
@@ -85,8 +98,8 @@ TEST_CASE("CGAL parallel insertion and removal retain their lock-grid owner" *
     auto& delaunay = moved.mutable_triangulation_unchecked();
     std::vector<Vertex_handle_t<3>> vertices_to_remove;
     vertices_to_remove.reserve(16);
-    auto vertex = delaunay.finite_vertices_begin();
-    for (std::size_t count = 0; count < 16; ++count, ++vertex)
+    for (auto const vertex :
+         delaunay.finite_vertex_handles() | std::views::take(16))
     {
       vertices_to_remove.emplace_back(vertex);
     }
@@ -106,6 +119,64 @@ TEST_CASE("CGAL parallel insertion and removal retain their lock-grid owner" *
   CHECK_FALSE(snapshot.is_parallel());
   CHECK(snapshot.get_lock_data_structure() == nullptr);
   CHECK(snapshot.is_valid());
+}
+
+TEST_CASE("A failed concurrent lock leaves the triangulation unchanged" *
+          doctest::test_suite("parallel_triangulation"))
+{
+  Causal_vertices_t<3> const vertices{
+      {Point_t<3>{-1.0, -1.0, -1.0}, 1},
+      { Point_t<3>{1.0, -1.0, -1.0}, 1},
+      { Point_t<3>{-1.0, 1.0, -1.0}, 2},
+      { Point_t<3>{-1.0, -1.0, 1.0}, 2},
+      {   Point_t<3>{1.0, 1.0, 1.0}, 3},
+  };
+  detail::Delaunay_state<3> state{vertices};
+  auto&       triangulation = state.mutable_triangulation_unchecked();
+  auto* const lock_grid     = state.lock_data_structure();
+  REQUIRE(lock_grid != nullptr);
+
+  Point_t<3> const candidate{0.125, 0.25, 0.375};
+  auto const       start = *triangulation.finite_cell_handles().begin();
+  auto const       contested_point = start->vertex(0)->point();
+  REQUIRE(lock_grid->template try_lock<true>(contested_point));
+  lock_grid->unlock_all_points_locked_by_this_thread();
+
+  std::latch       locked{1};
+  std::latch       release{1};
+  std::atomic_bool lock_acquired{false};
+  std::jthread     holder{[&] {
+    lock_acquired.store(lock_grid->template try_lock<true>(contested_point));
+    locked.count_down();
+    release.wait();
+    lock_grid->unlock_all_points_locked_by_this_thread();
+  }};
+  locked.wait();
+  if (!lock_acquired.load())
+  {
+    release.count_down();
+    holder.join();
+    FAIL_CHECK("The fixture thread could not acquire the candidate lock.");
+    return;
+  }
+
+  auto const vertices_before = triangulation.number_of_vertices();
+  auto const cells_before    = triangulation.number_of_finite_cells();
+  bool       could_lock_zone = true;
+  auto const inserted =
+      triangulation.insert(candidate, start, &could_lock_zone);
+
+  CHECK_FALSE(could_lock_zone);
+  CHECK(inserted == Vertex_handle_t<3>{});
+  CHECK_EQ(triangulation.number_of_vertices(), vertices_before);
+  CHECK_EQ(triangulation.number_of_finite_cells(), cells_before);
+  CHECK_FALSE(find_vertex<3>(triangulation, candidate));
+  CHECK(triangulation.is_valid());
+
+  triangulation.unlock_all_elements();
+  release.count_down();
+  holder.join();
+  CHECK(lock_grid->check_if_all_cells_are_unlocked());
 }
 
 TEST_CASE("Parallel lock ownership survives wrapper value transfers" *

--- a/tests/Tetrahedron_test.cpp
+++ b/tests/Tetrahedron_test.cpp
@@ -73,7 +73,8 @@ SCENARIO("Find distances between points of the tetrahedron" *
   using Point                 = Point_t<3>;
   using Causal_vertices       = Causal_vertices_t<3>;
   using FoliatedTriangulation = FoliatedTriangulation_3;
-  using squared_distance = detail::TriangulationTraits<3>::squared_distance;
+  using squared_distance =
+      cdt::detail::TriangulationTraits<3>::squared_distance;
   GIVEN("Points in a tetrahedron.")
   {
     auto origin         = Point{0, 0, 0};


### PR DESCRIPTION
- require the exact CGAL baseline and its supported compiler floors
- adopt canonical CGAL simplex types, finite ranges, and metadata safeguards
- make optional oneTBB concurrency and lock-grid ownership explicit
- document and benchmark the supported integration contract

BREAKING CHANGE: CDT++ now requires exactly CGAL 6.2, GCC 13.3 or Clang 22 on those toolchains, and removes the legacy Face_handle_t alias.

Closes #102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new configurable CGAL benchmark (workloads adjustable) and supporting scripts/recipes.
  * Introduced stricter correctness checking APIs (structural vs diagnostics-driven validation).
* **Bug Fixes**
  * Improved validation for duplicate points and out-of-range time values.
  * Strengthened guarantees around concurrent operations (failed locks leave triangulation unchanged) and label/time preservation.
* **Documentation**
  * Added/updated the CGAL 6.2 integration contract and refreshed testing expectations.
* **Chores**
  * Tightened build/tooling requirements (CGAL 6.2 exact, higher compiler minimums, deprecation-as-errors option, toolchain workflow updates).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->